### PR TITLE
Merging fixes from Samuel

### DIFF
--- a/src/Campaigns/City of Bywater/Maps/test_map/map_scripts.gd
+++ b/src/Campaigns/City of Bywater/Maps/test_map/map_scripts.gd
@@ -96,7 +96,7 @@ static func Find_Treasure() :
 	for i in range(200) :
 		var healpotion = healpottemplate.duplicate(true)
 		treasureitems.append(healpotion)
-	GameGlobal.show_loot_menu(treasureitems,[10,5,3],2000)
+	await GameGlobal.show_loot_menu(treasureitems,[10,5,3],2000)
 	#yield(textRect, "interruption_over")
 
 static func Take_Stairs_D() :

--- a/src/scenes/Map/CombatCharacter.gd
+++ b/src/scenes/Map/CombatCharacter.gd
@@ -152,7 +152,7 @@ func set_creature_represented(crea) : #Crea is a creature.gd instance, or a play
 #	print("set_creature_represented : ", crea)
 #	sprite.texture = crea.textureL
 	if crea.get("icon") :
-		print("CombatCharacter "+crea.name+" must be a PC !")
+		#print("CombatCharacter "+crea.name+" must be a PC !")
 		set_icon(crea.icon, crea.size)
 	else :
 		set_icon(crea.textureL, crea.size)

--- a/src/scenes/MyAstar2D.gd
+++ b/src/scenes/MyAstar2D.gd
@@ -40,6 +40,9 @@ func generate_graph(mapdata : Array, swimmer : bool, flyer : bool, big : bool) :
 		for ts in l :
 			var weight : float = get_tilestack_cost(ts, swimmer, flyer, big)
 			pos = Vector2i(y,x)
+			#if big :
+				#print("astar big crea : "+str(pos)+' size:'+str(crea_size)+' w8:' + str(weight))
+			
 #			print("ASTAR : tile at "+str(pos)+" is "+ts[0]["name"]+" and weight "+str(weight))
 #			set_point_solid(pos, weight<0)
 			if weight>=0 :
@@ -57,10 +60,10 @@ func specific_set_point_weight_scale(pos : Vector2i, weight_scale: float) :
 	var region_end : Vector2i = region.end
 	for cx in range(crea_size.x) :
 		for cy in range(crea_size.y) :
-			if pos.x+cx<region_end.x and pos.y+cy<region_end.y :
-				var bpos : Vector2i =  pos+Vector2i(cx,cy)
+			if pos.x-cx<region_end.x and pos.y-cy<region_end.y and pos.x-cx>=0 and pos.y-cy>=0 :
+				var bpos : Vector2i =  pos-Vector2i(cx,cy)
 				var prev_weight : float = get_point_weight_scale(bpos)
-				set_point_weight_scale(pos+Vector2i(cx,cy), max(weight_scale,prev_weight))
+				set_point_weight_scale(pos-Vector2i(cx,cy), max(weight_scale,prev_weight))
 	
 
 func get_tilestack_cost(ts : Array, swimmer : bool, flyer : bool, big : bool) -> float :

--- a/src/scenes/UI/HUD/CreatureCBRect/LogRect.gd
+++ b/src/scenes/UI/HUD/CreatureCBRect/LogRect.gd
@@ -66,7 +66,7 @@ func log_melee_attack(attacker : CombatCreaButton, defender : CombatCreaButton, 
 	detaillabel.bbcode_enabled = true
 	detailtext += "    ("
 	for t in damage_detail :
-		if t!="total" :
+		if not ["total", "is_crit", "crit_mult"].has(t) :
 			var tcolor : Color = attrColorDict[t]
 			var tcol_string : String = '#'+tcolor.to_html()
 			if needcomma :

--- a/src/scenes/UI/HUD/Looting/LootSelectionCircleDisabled.png
+++ b/src/scenes/UI/HUD/Looting/LootSelectionCircleDisabled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:64354679651699c404f6f69fc76b1c9ae975b828bf7c752c10fbd908ebb7376f
-size 253
+oid sha256:829d106d518f8d1e309d0d8661023c3333ee98b336ff43fc2f473eb5712231d2
+size 142

--- a/src/scenes/UI/HUD/Looting/TreasureControl.gd
+++ b/src/scenes/UI/HUD/Looting/TreasureControl.gd
@@ -52,7 +52,7 @@ func display(items : Array, money : Array, experience : int) :
 	exp = experience
 	exp_receivers.clear()
 	for pc : PlayerCharacter in GameGlobal.player_characters :
-		if pc.get_stat("curHP")>0 :
+		if pc.get_stat("curHP")<=0 :
 			continue
 		for t in pc.traits :
 			if t.trait_types.has("no_exp") :
@@ -133,7 +133,7 @@ func close() :
 	get_parent().set_charactersRect_type(0)
 	get_parent().moneyControl.close()
 	NodeAccess.__Map().show()
-	emit_signal( "done_looting")
+	emit_signal("done_looting")
 	print("teasure_control  close()")
 	hide()
 

--- a/src/scenes/UI/HUD/OWHUDControl.gd
+++ b/src/scenes/UI/HUD/OWHUDControl.gd
@@ -563,6 +563,7 @@ func exit_battle_mode() :
 	
 func set_selected_creature(c : Creature) : # for battle, any creature on field not just pc
 	#also check called_on_CharPanel_SelectButton_pressed
+	print("OWHUD set_selected_creature "+c.name)
 	selected_character = c
 	if GameGlobal.player_characters.has(c) or GameGlobal.player_allies.has(c) : #select the right character
 		for p in charsVContainer.get_children() :

--- a/src/scripts/GameGlobal.gd
+++ b/src/scripts/GameGlobal.gd
@@ -335,7 +335,7 @@ func is_map_tile_walkable_by_char(chara, pos : Vector2)->bool : #battle mode, ch
 #	print("gamestate is_map_tile_walkable_by_char ",  chara.name, " ,pos: ", pos)
 #	print("is_map_tile_walkable_by_char TODO check character itself :")
 #	print("map.mapdata[pos.x][pos.y]", map.mapdata[pos.x][pos.y])
-	
+	print("GameGlobal is_map_tile_walkable_by_char "+chara.name+" pos:"+str(pos))
 	var tileitemlightstack : Array = map.mapdata[pos.x][pos.y]
 	if tileitemlightstack.is_empty() :
 		return false
@@ -412,9 +412,17 @@ func end_battle( wonfledlost : String ) :
 					money_drop[g] += c.money[g]
 				for i in c.inventory :
 					treasureitems.append(i)
+			
+			#this won't show the allies  screen
+			#await UI.ow_hud.show_loot_menu(treasureitems,money_drop,experience)
+			
+			
 			StateMachine.transition_to("Exploration/ExMenus", {"menu_name" : "LootMenu", "treasure" : treasureitems, "money" : money_drop, "exp" : experience, "prev_state" : "Exploration"})
-			#show_loot_menu(treasureitems,money_drop,20)
-			#await UI.ow_hud.treasureControl.done_looting
+			await UI.ow_hud.treasureControl.done_looting
+			print("done looting")
+			
+			
+			
 			#show_allies_menu()
 			#await UI.ow_hud.alliesCtrl.done_allying
 			##GameState._combat_state = eCombatStates.unchecked

--- a/src/scripts/states/CombatState.gd
+++ b/src/scripts/states/CombatState.gd
@@ -105,7 +105,7 @@ func check_los(fromV : Vector2, toV : Vector2) -> bool :
 
 
 
-func add_pc_or_npcally_to_battle_map(crea : Creature, init_pos : Vector2) -> bool:
+func add_pc_or_npc_ally_to_battle_map(crea : Creature, init_pos : Vector2) -> bool:
 	if crea.get_stat("curHP")<=0 or (not crea.joins_combat):
 		return false
 	var move_attempts : int = 0

--- a/src/scripts/states/ExMenusState.gd
+++ b/src/scripts/states/ExMenusState.gd
@@ -56,6 +56,7 @@ func enter(_msg : Dictionary = {} ) ->void :
 			UI.ow_hud.spellcastMenu.initialize(_msg["selected_character"])
 			UI.ow_hud.spellcastMenu.show()
 		"LootMenu" :
+			cur_menu_name = menu_name
 			await GameGlobal.show_loot_menu(_msg["treasure"],_msg["money"],_msg["exp"])
 			#if not GameGlobal.player_allies.is_empty() :
 			GameGlobal.show_allies_menu()
@@ -84,11 +85,13 @@ func exit() :
 
 
 func _state_process(_delta : float) -> void :
-	#print("cur_menu_name : "+cur_menu_name)
+	#print("cur_menu_name : "+ cur_menu_name)
 	if cur_menu_name== "PC_Pick" :
 		var cursorid : int = min(8, need_to_pick_n - picked_charapanels.size() )
 		#print(cursorid)
 		Input.set_custom_mouse_cursor(UI.cursor_numbers[cursorid])
+	#if cur_menu_name== "LootMenu" :
+		#Input.set_custom_mouse_cursor((UI.cursor_sword))
 
 func _on_chara_panel_selected_for_picking(cp : CharaSmallPanel) :
 


### PR DESCRIPTION
Issues I reported were as follows:

Campaign selection:

- No error indication when trying to add a character to the party before a campaign has selected, the UI simply doesnt respond.

City of Bywater (one-character party):

- In Town: Moving to the start event tile that normally gives the scenario intro just throws "Invalid get index 'rug_dungeon_floor'
- In Combat: Attempting to walk into a non-walkable space ends the character's turn prematurely
- In Combat: Moving to far south causes error "Invalid get index '90'", this is running for 90 >= x >= 93 with a subloop of 44 >= y >= 75, this is in the is_map_tile_walkable_by_char function. This error is pretty much a game stopper with the debugger running.
- In Town: the first 2x2 event block (outlined by pink) teleports you to the castle anthrax courtyard, moving east one step changes the cursor to a "2" (party assignment). I can only "assign" by clicking on the bar to the left of portraits, and the numerical indicators on the portraits do not clear properly nor are they centered or use the correct font and color.
- In Loot screen: The selection outline does not clear after picking up an item. (Is there no item limit? IIRC the original limited characters to 30 items. I know this isn't intended to be a faithful reproduction, just noting here in the event this needs consideration.)
- In Combat: On loading with the NPC ally, an error is thrown "Invalid Call. Nonexistent function 'add_pc_or_npc_ally_to_battle_map' in base 'Node (CombatState)'

Responses from Samuel included

> the "rug dungeon floor" error  is normal,  it's from an old test i didnt remove, not a bug in  the core.
The  "assigning " by  clicking  the bars next to  the portraits is just how I coded, I could change it.
Yea, i didnt up a max items limit  (yet). the outline thing is  def a bug i had ignored.
The NPC ally used to work, I must have broke it since. Maybe I had moved that function to anther  script ?

> The   combat  non-walk-able floor and invalid index 90 ones are definitely bugs

> the add_pc_or_npc_ally_to_battle_map  thing was just a typo

> that  out of bound index error happens   outside of combat too....

> I  found the problem with is_map_tile_walkable_by_char  ,  the problem was in  GameGlobals.find_path, when it checked  if the destination  point has a creature on it (making it the target)  i temporarily unblocks  its position and the rest of the area it covers  ... but it was  checking the  CombatButton's  (the sprite) size,  not the combat button's  creature 's  size in tiles
for y in range(who.creature.size.y) :    used to have just   who.size.y
the  turn ending when  you  do an invalid  action like walking into a wall during combat  was   a sort of  crash-proof  for buggy  AI,  the problem was the  decide action state   not checking if  your input led to a possible  action  before transitioning to  the  animation  state
fixed  too