### PR TITLE
Return empty array for missing directories

### DIFF
--- a/src/scripts/Utils.gd
+++ b/src/scripts/Utils.gd
@@ -107,10 +107,14 @@ class FileHandler:
 		
 	static func list_files_in_directory(path) -> Array :  #copied from profileslist.gd
 		var dir = DirAccess.open(path)
+		if dir == null:
+			return [] 
 		return dir.get_files()
 
 	static func list_dirs_in_directory(path) :
 		var dir = DirAccess.open(path)
+		if dir == null:
+			return []
 		return dir.get_directories()
 
 	static func get_cfg_setting(path, section, key, default) :


### PR DESCRIPTION
When trying to list files or directories if the requested path does not exist an empty array will be returned. 

Fixes https://github.com/Realmz-Castle/Realmz-Remake/issues/4 and other errors caused by folders that are missing