### PR TITLE
Fix MCP-injected key inputs causing infinite movement

### DIFF
--- a/.github/workflows/verify-dev.yml
+++ b/.github/workflows/verify-dev.yml
@@ -74,6 +74,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure Git LFS
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: git config -f .lfsconfig lfs.url https://${{env.LFS_USERNAME}}:${{env.LFS_PASSWORD}}@git-lfs-s3-proxy-984.pages.dev/c8076907f522754d603bf3b68096609c.r2.cloudflarestorage.com/realmz-remake
 
       - name: Checkout LFS
@@ -136,6 +137,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure Git LFS
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: git config -f .lfsconfig lfs.url https://${{env.LFS_USERNAME}}:${{env.LFS_PASSWORD}}@git-lfs-s3-proxy-984.pages.dev/c8076907f522754d603bf3b68096609c.r2.cloudflarestorage.com/realmz-remake
 
       - name: Checkout LFS
@@ -198,6 +200,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure Git LFS
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: git config -f .lfsconfig lfs.url https://${{env.LFS_USERNAME}}:${{env.LFS_PASSWORD}}@git-lfs-s3-proxy-984.pages.dev/c8076907f522754d603bf3b68096609c.r2.cloudflarestorage.com/realmz-remake
 
       - name: Checkout LFS
@@ -257,6 +260,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure Git LFS
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: git config -f .lfsconfig lfs.url https://${{env.LFS_USERNAME}}:${{env.LFS_PASSWORD}}@git-lfs-s3-proxy-984.pages.dev/c8076907f522754d603bf3b68096609c.r2.cloudflarestorage.com/realmz-remake
 
       - name: Checkout LFS

--- a/src/project.godot
+++ b/src/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Realmz"
-config/version="0.1.104"
+config/version="0.1.105"
 run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.6")
 boot_splash/bg_color=Color(0, 0, 0, 1)

--- a/src/scripts/game_state.gd
+++ b/src/scripts/game_state.gd
@@ -19,11 +19,25 @@ var time_since_last_dir_input : float = 0
 #var last_dir_input : Vector2i = Vector2i.ZERO
 #var last_nonnull_dir_input : Vector2i = Vector2i.ZERO
 
+const MOVE_ACTIONS : Array[StringName] = [
+	&"move_up", &"move_down", &"move_left", &"move_right",
+	&"move_upleft", &"move_upright", &"move_downleft", &"move_downright",
+]
+
 func _init() -> void :
 	add_to_group("state_machine")
 
-#func _unhandled_input(event : InputEvent) -> void :
-#	state.unhandled_input(event)
+# Edge-triggered movement: fires one move on the just-pressed edge of any
+# movement action. Polling in _process still handles continuous walking when a
+# real keyboard key stays held. is_action_pressed(action) excludes echo events,
+# so keyboard auto-repeat doesn't double-fire here.
+func _input(event : InputEvent) -> void :
+	for action in MOVE_ACTIONS :
+		if event.is_action_pressed(action) :
+			var arr : Array = get_dir_input_from_kb()
+			if arr[1] :
+				send_dir_input(arr[0], true)
+			return
 
 
 


### PR DESCRIPTION
Movement was poll-based: _process checked Input.is_action_pressed every 0.2s, which works for real keyboards (OS sends key-up on release) but breaks for AI-injected events that never auto-release. The action stayed "pressed" forever and the poll fired indefinitely.

Add an edge-triggered _input handler that fires one move on the just-pressed edge of any movement action and resets the poll timer. Real keyboards still get continuous walk via the existing _process poll when held. is_action_pressed(action) filters echo events so keyboard auto-repeat doesn't double-fire.

Pairs with an auto-release in the local godot_mcp runtime helper to guarantee MCP key events behave as taps.