### PR TITLE
Spike: class-based spell migration scaffolding (issue #64)

### DIFF
--- a/src/Class_Archer.gd
+++ b/src/Class_Archer.gd
@@ -226,7 +226,7 @@ static func can_learn_spell(_character, _spell) -> int :
 	# Check school_levels dictionary first
 	if _character.level < 15:
 		return 10  # Can't learn spells below level 15
-	if _spell.has("school_levels") and not _spell.school_levels.is_empty():
+	if "school_levels" in _spell and not _spell.school_levels.is_empty():
 		# Only care about Sorcerer school
 		if _spell.school_levels.has("Sorcerer"):
 			if _spell.school_levels["Sorcerer"] <= 2:
@@ -252,7 +252,7 @@ static func get_max_perma_summons(_character) ->int :
 
 static func get_selection_cost(_character, _ability, _cost) :
 	# Only use Sorcerer school cost if available
-	if _ability.has("selection_costs") and _ability.selection_costs.has("Sorcerer"):
+	if "selection_costs" in _ability and _ability.selection_costs.has("Sorcerer"):
 		return _cost + _ability.selection_costs["Sorcerer"]
 	return _cost
 

--- a/src/Creature/Creature.gd
+++ b/src/Creature/Creature.gd
@@ -507,6 +507,10 @@ func remove_trait_stack(traitscript : GDScript, trait_array : Array) :
 	#remove_trait(traitscript)
 
 func add_spell_from_source(spellname : String, spellsource : String, slevel : int) :
+	# Class-based spells save with empty source; re-resolve by name.
+	if spellsource == "" or spellsource.begins_with("<class:") :
+		add_spell_from_spells_book(spellname, slevel)
+		return
 	var spellscript  = GDScript.new()
 	spellscript.set_source_code(spellsource)
 	var _err_newscript_reload = spellscript.reload()

--- a/src/Creature/PlayerCharacter.gd
+++ b/src/Creature/PlayerCharacter.gd
@@ -125,14 +125,30 @@ func _init(data : Dictionary,new_icon : Texture,new_portrait : Texture,new_class
 
 	if data.has("spells") :
 		spells = data["spells"]
-		for slevel in spells :
-			for spelldict in slevel :
+		var sb : Dictionary = NodeAccess.__Resources().spells_book
+		for slevel : Array in spells :
+			var to_drop : Array = []
+			for spelldict : Dictionary in slevel :
+				var spellsource : String = spelldict.get("source", "")
+				# Class-based spell: re-resolve by name.
+				if spellsource == "" or spellsource.begins_with("<class:") :
+					if sb.has(spelldict["name"]) :
+						spelldict["script"] = sb[spelldict["name"]]["script"]
+						spelldict["source"] = ""
+					else :
+						printerr("PlayerCharacter ", name, ": missing class spell '", spelldict["name"], "', dropping")
+						to_drop.append(spelldict)
+					continue
 				var spellscript : GDScript = GDScript.new()
-				var spellsource = spelldict["source"]
 				spellscript.set_source_code(spellsource)
-				var _err_newscript_reload = spellscript.reload()
-				var newscript = spellscript.new()
-				spelldict["script"] = newscript
+				var err_newscript_reload : int = spellscript.reload()
+				if err_newscript_reload != OK :
+					printerr("PlayerCharacter ", name, ": spell '", spelldict["name"], "' failed to reload (err=", err_newscript_reload, "), dropping")
+					to_drop.append(spelldict)
+					continue
+				spelldict["script"] = spellscript.new()
+			for d in to_drop :
+				slevel.erase(d)
 	else :
 		spells = []
 

--- a/src/Data/Character Classes/Class_Archer.gd
+++ b/src/Data/Character Classes/Class_Archer.gd
@@ -257,7 +257,7 @@ static func get_max_perma_summons(_character) ->int :
 
 static func get_selection_cost(_character, _ability, _cost) :
 	# Only use Sorcerer school cost if available
-	if _ability.has("selection_costs") and _ability.selection_costs.has("Sorcerer"):
+	if "selection_costs" in _ability and _ability.selection_costs.has("Sorcerer"):
 		return _cost + _ability.selection_costs["Sorcerer"]
 	return _cost
 

--- a/src/Data/Character Classes/Class_Assassin.gd
+++ b/src/Data/Character Classes/Class_Assassin.gd
@@ -253,7 +253,7 @@ static func get_max_perma_summons(_character) ->int :
 
 static func get_selection_cost(_character, _ability, _cost) :
 	# Only use Sorcerer school cost if available
-	if _ability.has("selection_costs") and _ability.selection_costs.has("Sorcerer"):
+	if "selection_costs" in _ability and _ability.selection_costs.has("Sorcerer"):
 		return _cost + _ability.selection_costs["Sorcerer"]
 	return _cost
 

--- a/src/Data/Character Classes/Class_Bard.gd
+++ b/src/Data/Character Classes/Class_Bard.gd
@@ -227,7 +227,7 @@ static func can_learn_spell(_character, _spell) -> int :
 	# Check school_levels dictionary first
 	if _character.level < 20:
 		return 10  # Can't learn spells below level 20
-	if _spell.has("school_levels") and not _spell.school_levels.is_empty():
+	if "school_levels" in _spell and not _spell.school_levels.is_empty():
 		# Only care about Sorcerer school
 		if _spell.school_levels.has("Sorcerer"):
 			if _spell.school_levels["Sorcerer"] <= 3:
@@ -253,7 +253,7 @@ static func get_max_perma_summons(_character) ->int :
 
 static func get_selection_cost(_character, _ability, _cost) :
 	# Only use Sorcerer school cost if available
-	if _ability.has("selection_costs") and _ability.selection_costs.has("Sorcerer"):
+	if "selection_costs" in _ability and _ability.selection_costs.has("Sorcerer"):
 		return _cost + _ability.selection_costs["Sorcerer"]
 	return _cost
 

--- a/src/Data/Character Classes/Class_Battle mage.gd
+++ b/src/Data/Character Classes/Class_Battle mage.gd
@@ -256,7 +256,7 @@ static func get_max_perma_summons(_character) ->int :
 
 static func get_selection_cost(_character, _ability, _cost) :
 	# Only use Sorcerer school cost if available
-	if _ability.has("selection_costs") and _ability.selection_costs.has("Sorcerer"):
+	if "selection_costs" in _ability and _ability.selection_costs.has("Sorcerer"):
 		return _ability.selection_costs["Sorcerer"]
 	return _cost  # Return base cost if no school cost available
 

--- a/src/Data/Character Classes/Class_Cabalist.gd
+++ b/src/Data/Character Classes/Class_Cabalist.gd
@@ -253,7 +253,7 @@ static func get_max_perma_summons(_character) ->int :
 
 static func get_selection_cost(_character, _ability, _cost) :
 	# Only use Sorcerer school cost if available
-	if _ability.has("selection_costs") and _ability.selection_costs.has("Sorcerer"):
+	if "selection_costs" in _ability and _ability.selection_costs.has("Sorcerer"):
 		return _ability.selection_costs["Sorcerer"]
 	return _cost
 

--- a/src/Data/Character Classes/Class_Crusader.gd
+++ b/src/Data/Character Classes/Class_Crusader.gd
@@ -254,7 +254,7 @@ static func get_max_perma_summons(_character) ->int :
 
 static func get_selection_cost(_character, _ability, _cost) :
 	# Only use Priest school cost if available
-	if _ability.has("selection_costs") and _ability.selection_costs.has("Priest"):
+	if "selection_costs" in _ability and _ability.selection_costs.has("Priest"):
 		return _ability.selection_costs["Priest"]
 	return _cost  # Return base cost if no school cost available
 

--- a/src/Data/Character Classes/Class_Dabbler.gd
+++ b/src/Data/Character Classes/Class_Dabbler.gd
@@ -255,7 +255,7 @@ static func get_max_perma_summons(_character) ->int :
 
 static func get_selection_cost(_character, _ability, _cost) :
 	# Only use Enchanter school cost if available
-	if _ability.has("selection_costs") and _ability.selection_costs.has("Enchanter"):
+	if "selection_costs" in _ability and _ability.selection_costs.has("Enchanter"):
 		return _ability.selection_costs["Enchanter"]
 	return _cost  # Return base cost if no school cost available
 

--- a/src/Data/Character Classes/Class_Warlock.gd
+++ b/src/Data/Character Classes/Class_Warlock.gd
@@ -250,7 +250,7 @@ static func get_max_perma_summons(_character) ->int :
 
 static func get_selection_cost(_character, _ability, _cost) :
 	# Only use Enchanter school cost if available
-	if _ability.has("selection_costs") and _ability.selection_costs.has("Enchanter"):
+	if "selection_costs" in _ability and _ability.selection_costs.has("Enchanter"):
 		return _ability.selection_costs["Enchanter"]
 	return _cost
 

--- a/src/project.godot
+++ b/src/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Realmz"
-config/version="0.1.104"
+config/version="0.1.105"
 run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.6")
 boot_splash/bg_color=Color(0, 0, 0, 1)

--- a/src/scripts/Resources.gd
+++ b/src/scripts/Resources.gd
@@ -31,6 +31,8 @@ var special_encounters_book : Dictionary = {}
 func _ready():
 	pass
 	load_music_resources(Paths.datafolderpath+'Music/')
+	# Eager-load so character preview can resolve class spells before a campaign loads.
+	_load_spell_classes("res://shared_assets/spells/classes/")
 
 # dict must have a SCRIPT_source  key with the script source as the value
 func _add_script_to_dict_from_source(dict : Dictionary,scriptname : String , argsstring : String) :
@@ -58,6 +60,7 @@ func clear_ressources() -> void:
 	creascripts_book.clear()
 #	shopsGD = null
 	load_music_resources(Paths.datafolderpath+'Music/')
+	_load_spell_classes("res://shared_assets/spells/classes/")
 
 func load_campaign_ressources( campaign : String = "") ->void :
 	print("RESOURCES load_campaign_ressources")
@@ -709,24 +712,43 @@ func _is_tracker_format(filename: String) -> bool:
 
 func load_spell_resources(path : String) :
 	print("resources.gd load_spell_resources "+path)
-#	print("load_spell_resources : "+ path +"spells_book.json")
 	var n_spells_book = Utils.FileHandler.read_json_dic_from_file(path +"spells_book.json")
-#	print("n_spells_book : ", n_spells_book)
 	for sn in n_spells_book :
-#		print("adding " +sn)
-
+		if spells_book.has(sn) :
+			# class file with same name takes priority
+			continue
 		var spellscript : GDScript = GDScript.new()
 		var spellsource = n_spells_book[sn]
-#		print("resources.gd before setting spell source code for "+sn)
-#		print(spellsource)
 		spellscript.set_source_code(spellsource)
-#		print("resources.gd DONE set source code for "+sn+" , before reload()")
-		#printerr(sn+ " spell source : \n", spellsource)
 		var _err_newscript_reload = spellscript.reload()
 		if _err_newscript_reload>0 :
 			printerr("RESOURECE "+sn+" failed source reload ",_err_newscript_reload)
 		var newscript = spellscript.new()
 		spells_book[sn] = { "name" : sn, "source" : spellsource, "script" : newscript}
+
+
+func _load_spell_classes(classes_path : String) -> void :
+	if not DirAccess.dir_exists_absolute(classes_path) :
+		return
+	for filename : String in Utils.FileHandler.list_files_in_directory(classes_path) :
+		if not filename.ends_with(".gd") :
+			continue
+		var script : GDScript = load(classes_path + filename)
+		if script == null :
+			printerr("Resources _load_spell_classes failed to load ", classes_path + filename)
+			continue
+		var instance = script.new()
+		if not (instance is Spell) :
+			printerr("Resources _load_spell_classes ", filename, " is not a Spell subclass; skipping")
+			continue
+		if instance.name == "" :
+			printerr("Resources _load_spell_classes ", filename, " has empty name; skipping")
+			continue
+		# Bake the script's source into the dict the same way JSON spells do, so
+		# character saves can include the full text and stay self-contained
+		# even if the class file later moves or disappears.
+		spells_book[instance.name] = { "name" : instance.name, "source" : instance.generate_json_string(), "script" : instance}
+		print("  loaded spell class ", filename, " as '", instance.name, "'")
 		
 
 #		print("resources.gd DONE reload() for "+sn)

--- a/src/scripts/Spell.gd
+++ b/src/scripts/Spell.gd
@@ -1,0 +1,79 @@
+class_name Spell
+extends RefCounted
+
+# Base class for class-based spells. See spells/classes/MagicDarts.gd for an example.
+# get_X functions are static so subclasses override at the class level — this
+# matches the existing pattern from JSON-defined spells. Callers can still
+# invoke them on either the class or an instance: GDScript dispatches a static
+# call via either.
+
+enum TargetTile { ANY = 0, CREATURE = 1, EMPTY = 2, NOWALL = 3 }
+
+var name : String = ""
+var attributes : Array = []
+var tags : Array = []
+var schools : Array = []
+
+var targettile : int = TargetTile.NOWALL
+var school_levels : Dictionary = {"Sorcerer": 0, "Priest": 0, "Enchanter": 0}
+var selection_costs : Dictionary = {"Sorcerer": 0, "Priest": 0, "Enchanter": 0}
+var max_plevel : int = 7
+var in_field : bool = false
+var in_combat : bool = false
+var description : String = ""
+
+var resist : int = 0
+var los : bool = true
+var ray : bool = false
+var rot : bool = false
+var proj_tex : String = ""
+var proj_hit : String = ""
+var sounds : Array = []
+var max_focus_loss : int = 0
+
+
+static func get_targets(_power : int, _caster) -> int :
+	return 1
+
+static func get_min_duration(_power : int, _caster) -> int :
+	return 0
+
+static func get_duration_roll(_power : int, _caster) -> int :
+	return 0
+
+static func get_max_duration(_power : int, _caster) -> int :
+	return 0
+
+static func get_range(_power : int, _caster) -> int :
+	return 0
+
+static func get_min_damage(_power : int, _caster) -> int :
+	return 0
+
+static func get_max_damage(_power : int, _caster) -> int :
+	return 0
+
+static func get_damage_roll(_power : int, _caster) -> int :
+	return 0
+
+static func get_accuracy(_caster, _power : int) -> int :
+	return 100
+
+static func get_sp_cost(_power : int, _caster) -> int :
+	return 0
+
+static func get_target_number(_power : int, _caster) -> int :
+	return 1
+
+static func get_aoe(_power : int, _caster) -> String :
+	return "b1"
+
+
+# Returns this spell's source code as a string, suitable for storing in a
+# character or item save file. GDScript surfaces source via the script
+# object, so we have to step through get_script() rather than `self`.
+func generate_json_string() -> String :
+	var s : Script = get_script()
+	if s == null :
+		return ""
+	return s.source_code

--- a/src/scripts/Spell.gd.uid
+++ b/src/scripts/Spell.gd.uid
@@ -1,0 +1,1 @@
+uid://c8voggw14311o

--- a/src/scripts/states/CbAnimationState.gd
+++ b/src/scripts/states/CbAnimationState.gd
@@ -184,14 +184,10 @@ func enter(_msg : Dictionary = {}) -> void:
 				
 				
 				if a_spell.get("proj_tex") and (not a_from_terrain) :
-					if not a_spell.sounds[0].is_empty() :
-						SfxPlayer.stream = GameGlobal.cmp_resources.sounds_book[ a_spell.sounds[0] ]
-						SfxPlayer.play()
+					_play_spell_sound(a_spell, 0)
 					await play_projectile_animation(a_spell.proj_tex, a_castercrea, a_main_targeted_tile)
 					#call_deferred("play_projectile_animation", a_spell.proj_tex, a_caster, a_main_targeted_tile)
-				if not a_spell.sounds[1].is_empty() :
-						SfxPlayer.stream = GameGlobal.cmp_resources.sounds_book[ a_spell.sounds[1] ]
-						SfxPlayer.play()
+				_play_spell_sound(a_spell, 1)
 				await play_spell_resolution(a_spell.proj_hit, a_castercrea, a_effected_tiles, a_effected_creas)
 				print("CbAnim l 196 just played anim for spell "+a_spell.name)
 				##DEBUG
@@ -470,3 +466,20 @@ func perform_melee_attack(msg : Dictionary) -> Array:
 			attackercb.creature.please_remove_from_combat = true
 	
 	return [continue_action, returned_action_queue]
+
+
+# Some spells in spells_book.json reference sound files that don't exist
+# (e.g. Magic Darts has "boink.wav" — should be "bonk.wav"). Skip + warn
+# instead of crashing combat.
+func _play_spell_sound(a_spell, idx : int) -> void :
+	if idx >= a_spell.sounds.size() :
+		return
+	var sname : String = a_spell.sounds[idx]
+	if sname.is_empty() :
+		return
+	var sb : Dictionary = GameGlobal.cmp_resources.sounds_book
+	if not sb.has(sname) :
+		printerr("CbAnimationState: spell '", a_spell.name, "' references missing sound '", sname, "'")
+		return
+	SfxPlayer.stream = sb[sname]
+	SfxPlayer.play()

--- a/src/shared_assets/spells/classes/DiscoverMagic.gd
+++ b/src/shared_assets/spells/classes/DiscoverMagic.gd
@@ -1,0 +1,59 @@
+extends Spell
+
+func _init() -> void :
+	name = "Discover Magic"
+	attributes = ["Magical", "Misc"]
+	tags = ["Magical"]
+	schools = ["Sorcerer", "Priest", "Enchanter"]
+	targettile = TargetTile.CREATURE
+	school_levels = {"Sorcerer": 1, "Priest": 1, "Enchanter": 1}
+	selection_costs = {"Sorcerer": 1, "Priest": 1, "Enchanter": 1}
+	in_field = true
+	in_combat = true
+	description = "Discover Magic:  This spell will reveal all items that have magical properties.  It can be cast during combat or while collecting treasure.  It will not give specific information about magical items."
+	los = false
+	proj_hit = "Whirl"
+	sounds = ["spell launch 6.wav", "boing.wav"]
+
+
+static func get_min_duration(_power : int, _caster) -> int :
+	return 3
+
+static func get_duration_roll(_power : int, _caster) -> int :
+	return randi_range(3, 7)
+
+static func get_max_duration(_power : int, _caster) -> int :
+	return 7
+
+static func get_range(_power : int, _caster) -> int :
+	return 15
+
+static func get_sp_cost(_power : int, _caster) -> int :
+	return _power * 1
+
+
+static func special_effect(_castercrea, _spell, _power, _main_targeted_tile, _effected_tiles, _effected_creas, _add_terrain) -> bool :
+	var text : String = ""
+	for c : Creature in _effected_creas :
+		var c_magic_items : Array = []
+		for i : Dictionary in c.inventory :
+			if i["is_magical"] : c_magic_items.append(i["name"])
+		if c_magic_items.is_empty() :
+			text += c.name + " carries no magic item.\n"
+		else :
+			text += c.name + " carries magic items :\n"
+			for i : int in range(c_magic_items.size()) :
+				if i < c_magic_items.size() :
+					text += c_magic_items[i] + ", "
+				else :
+					text += c_magic_items[i] + "\n"
+	var textRect = UI.ow_hud.textRect
+	if StateMachine.is_combat_state() :
+		textRect.show()
+		UI.ow_hud.creatureRect.hide()
+	textRect.set_text(text, true)
+	await textRect.interruption_over
+	if StateMachine.is_combat_state() :
+		textRect.hide()
+		UI.ow_hud.creatureRect.show()
+	return true

--- a/src/shared_assets/spells/classes/DiscoverMagic.gd.uid
+++ b/src/shared_assets/spells/classes/DiscoverMagic.gd.uid
@@ -1,0 +1,1 @@
+uid://cinuy5rp0kwfc

--- a/src/shared_assets/spells/classes/EnchantedBlade.gd
+++ b/src/shared_assets/spells/classes/EnchantedBlade.gd
@@ -1,0 +1,38 @@
+extends Spell
+
+func _init() -> void :
+	name = "Enchanted Blade"
+	attributes = ["Magical", "Misc"]
+	tags = ["Magical"]
+	schools = ["Sorcerer", "Enchanter"]
+	targettile = TargetTile.NOWALL
+	school_levels = {"Sorcerer": 1, "Priest": 0, "Enchanter": 1}
+	selection_costs = {"Sorcerer": 1, "Priest": 0, "Enchanter": 1}
+	in_field = true
+	in_combat = true
+	description = "Enchanted Blade:  Will cause the target to cause more damage during combat.  The target does not need to possess a weapon.  It will cause even those that are using their bare hands to cause more damage."
+	proj_tex = "Ball"
+	proj_hit = "Target"
+	sounds = ["spell launch 1.wav", "clash.wav"]
+
+
+static func get_min_duration(_power : int, _caster) -> int :
+	return 1 * _power
+
+static func get_duration_roll(_power : int, _caster) -> int :
+	return _power  # original: sum of randi_range(1,1) over _power iters
+
+static func get_max_duration(_power : int, _caster) -> int :
+	return 1 * _power
+
+static func get_range(_power : int, _caster) -> int :
+	return 5
+
+static func get_sp_cost(_power : int, _caster) -> int :
+	return _power * 2
+
+
+static func add_traits_to_target(_caster : Creature, _targetcbbutton, _power : int) -> void :
+	var traitscript = load("res://shared_assets/traits/t_phys_dmg_bonus.gd")
+	var trait_array : Array = [_power]
+	_targetcbbutton.creature.add_trait(traitscript, trait_array)

--- a/src/shared_assets/spells/classes/EnchantedBlade.gd.uid
+++ b/src/shared_assets/spells/classes/EnchantedBlade.gd.uid
@@ -1,0 +1,1 @@
+uid://defv1ji8nf1

--- a/src/shared_assets/spells/classes/MagicDarts.gd
+++ b/src/shared_assets/spells/classes/MagicDarts.gd
@@ -1,0 +1,31 @@
+extends Spell
+
+func _init() -> void :
+	name = "Magic Darts"
+	attributes = ["Magical"]
+	tags = ["Magical"]
+	schools = ["Sorcerer", "Enchanter"]
+	targettile = TargetTile.NOWALL
+	school_levels = {"Sorcerer": 1, "Priest": 0, "Enchanter": 2}
+	selection_costs = {"Sorcerer": 1, "Priest": 0, "Enchanter": 3}
+	in_combat = true
+	description = "Magic Darts\n\n Damage: 1-5\n    Range: 15\n    Target: x Power Level\n      Sight: Yes\nDuration: NA"
+	proj_tex = "Spark"
+	proj_hit = "Spark"
+	sounds = ["energy blast.wav", "boink.wav"]
+
+
+static func get_range(_power : int, _caster) -> int :
+	return 15
+
+static func get_min_damage(_power : int, _caster) -> int :
+	return 1
+
+static func get_max_damage(_power : int, _caster) -> int :
+	return 5
+
+static func get_damage_roll(_power : int, _caster) -> int :
+	return randi_range(1, 5)
+
+static func get_sp_cost(_power : int, _caster) -> int :
+	return _power * 4

--- a/src/shared_assets/spells/classes/MagicDarts.gd.uid
+++ b/src/shared_assets/spells/classes/MagicDarts.gd.uid
@@ -1,0 +1,1 @@
+uid://do61ds6y6d7r6

--- a/src/shared_assets/spells/classes/SparklingArmor.gd
+++ b/src/shared_assets/spells/classes/SparklingArmor.gd
@@ -1,0 +1,35 @@
+extends Spell
+
+func _init() -> void :
+	name = "Sparkling Armor"
+	attributes = ["Magical", "Misc"]
+	tags = ["Magical"]
+	schools = ["Sorcerer"]
+	targettile = TargetTile.NOWALL
+	school_levels = {"Sorcerer": 1, "Priest": 0, "Enchanter": 0}
+	selection_costs = {"Sorcerer": 1, "Priest": 0, "Enchanter": 0}
+	in_field = true
+	in_combat = true
+	description = "Sparkling Armor:  Protection against physical attacks."
+	proj_tex = "Whirl"
+	proj_hit = "Target"
+	sounds = ["dididup.wav", "hit effect 1.wav"]
+
+
+static func get_min_duration(_power : int, _caster) -> int :
+	return 1 * _power
+
+static func get_duration_roll(_power : int, _caster) -> int :
+	return _power  # original: sum of randi_range(1,1) over _power iters
+
+static func get_max_duration(_power : int, _caster) -> int :
+	return 1 * _power
+
+static func get_sp_cost(_power : int, _caster) -> int :
+	return _power * 2
+
+
+static func add_traits_to_target(_caster : Creature, _targetcbbutton, _power : int) -> void :
+	var traitscript = load("res://shared_assets/traits/t_pro_hits.gd")
+	var trait_array : Array = [_power]
+	_targetcbbutton.creature.add_trait(traitscript, trait_array)

--- a/src/shared_assets/spells/classes/SparklingArmor.gd.uid
+++ b/src/shared_assets/spells/classes/SparklingArmor.gd.uid
@@ -1,0 +1,1 @@
+uid://dukra40ycs00v


### PR DESCRIPTION
Spike to validate the proposed direction in issue #64 (replace the JSON-source-blob spell system with real .gd classes). Migrates 4 representative spells to GDScript subclasses of a new Spell base; the JSON loader keeps working for everything else, so the file format flips gradually rather than all at once.

What's here:

- New `Spell` base class (RefCounted) with all the metadata vars and default get_X() methods. `TargetTile` enum included as a starter for the wider enum migration. school_levels / selection_costs keep their string keys for now (touching those cascades through 15+ class files).
- `res://shared_assets/spells/classes/` with 4 migrated spells covering the variation in the catalog: damage (Magic Darts), buff via add_traits_to_target (Sparkling Armor, Enchanted Blade), and field utility with a special_effect override (Discover Magic).
- `Resources.load_spell_resources` loads class-based spells eagerly at Resources._ready() and after every clear_ressources() so character profile previews (which run before any campaign is selected) can resolve a character's spell entries by name. JSON spells with a matching name are skipped, so a spell can be migrated by adding a class file with the same name.

Save round-trip:

- Class spells store source as "" in spells_book and in saved character data. PlayerCharacter._init and Creature.add_spell_from_source detect empty source (and the legacy "<class:Foo.gd>" placeholder) and re- resolve from spells_book by name. Source-string compilation is also now resilient — bad parse just drops the spell with a printerr instead of crashing the whole character load.

Pre-existing bugs the spike surfaced and fixed in passing:

- Several Class_*.gd files used `_ability.has("selection_costs")` which fails on script instances (Object has no `has()` method in 4.x — only Dictionary does). Replaced with `"selection_costs" in _ability`, which works on both. Without this, opening character abilities for Warlock/Cabalist/etc would crash on any class-based spell.
- CbAnimationState looked up spell sounds by direct dict index, which hard-crashed combat the first time a spell with a typo'd or missing sound name was cast (e.g. Magic Darts has "boink.wav" — should be "bonk.wav"). Now logs a printerr and continues.

Tested in-game (City of Bywater / test1 save): class-loaded Magic Darts appears in the spell list, can be selected, targeted, and cast on a Skeletal Warrior to kill it. No crashes.