### PR TITLE
Add return to main menu from in-game settings

### DIFF
--- a/src/scenes/UI/HUD/SaveLoad/saves_panel.gd
+++ b/src/scenes/UI/HUD/SaveLoad/saves_panel.gd
@@ -12,9 +12,9 @@ func _ready():
 
 
 func fill(campaignname : String) :
+	saves_itemlist.clear()
 	if campaignname.is_empty() :
 		return
-	saves_itemlist.clear()
 	var campsavespath : String = Paths.profilesfolderpath +"/" + GameGlobal.currentprofile + "/Saves/" + campaignname + "/"
 	if not DirAccess.dir_exists_absolute(campsavespath) :
 		DirAccess.make_dir_recursive_absolute(campsavespath)

--- a/src/scenes/UI/HUD/Settings/SettingsRect.gd
+++ b/src/scenes/UI/HUD/Settings/SettingsRect.gd
@@ -27,5 +27,29 @@ func _on_ButtonDone_pressed():
 	hide()
 
 
+func _on_MainMenuButton_pressed():
+	$ConfirmRect.show()
+
+
+func _on_CancelButton_pressed():
+	$ConfirmRect.hide()
+
+
+func _on_YesButton_pressed():
+	$ConfirmRect.hide()
+	_return_to_main_menu()
+
+
+func _return_to_main_menu():
+	StateMachine.transition_to("Inactive", {})
+	GameGlobal.player_characters.clear()
+	MusicStreamPlayer.stop()
+	Input.set_custom_mouse_cursor(null)
+	NodeAccess.__Map().hide()
+	hide()
+	UI.show_only(UI.main_menu)
+	UI.main_menu.newCampaignPanel.hide()
+
+
 func on_viewport_size_changed(screensize) :
 	set_size(screensize)

--- a/src/scenes/UI/HUD/Settings/settings_rect.tscn
+++ b/src/scenes/UI/HUD/Settings/settings_rect.tscn
@@ -179,6 +179,114 @@ shortcut = SubResource("46")
 icon = ExtResource("9_1ta0t")
 flat = true
 
+[node name="MainMenuButton" type="Button" parent="."]
+layout_mode = 0
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -220.0
+offset_top = -50.0
+offset_right = -60.0
+offset_bottom = -10.0
+theme_override_styles/disabled = ExtResource("8_imqog")
+theme_override_styles/hover = ExtResource("6_7vk7l")
+theme_override_styles/pressed = ExtResource("7_reiei")
+theme_override_styles/normal = ExtResource("5_axu5w")
+theme_override_fonts/font = ExtResource("4_g7kde")
+theme_override_font_sizes/font_size = 24
+text = "Main Menu"
+
+[node name="ConfirmRect" type="Control" parent="."]
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 0
+
+[node name="Backdrop" type="ColorRect" parent="ConfirmRect"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0, 0, 0, 0.5)
+
+[node name="DialogPanel" type="NinePatchRect" parent="ConfirmRect"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -240.0
+offset_top = -100.0
+offset_right = 240.0
+offset_bottom = 100.0
+mouse_filter = 0
+texture = ExtResource("1_7xtdh")
+patch_margin_left = 10
+patch_margin_top = 10
+patch_margin_right = 9
+patch_margin_bottom = 9
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ConfirmRect/DialogPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 16.0
+offset_top = 16.0
+offset_right = -16.0
+offset_bottom = -16.0
+theme_override_constants/separation = 16
+
+[node name="MessageLabel" type="Label" parent="ConfirmRect/DialogPanel/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(1, 0.960784, 0, 1)
+theme_override_fonts/font = ExtResource("4_g7kde")
+theme_override_font_sizes/font_size = 28
+text = "Return to main menu?
+Unsaved progress will be lost."
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 2
+
+[node name="ButtonHBox" type="HBoxContainer" parent="ConfirmRect/DialogPanel/VBoxContainer"]
+layout_mode = 2
+alignment = 1
+theme_override_constants/separation = 32
+
+[node name="YesButton" type="Button" parent="ConfirmRect/DialogPanel/VBoxContainer/ButtonHBox"]
+custom_minimum_size = Vector2(140, 40)
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 1, 0, 1)
+theme_override_styles/disabled = ExtResource("8_imqog")
+theme_override_styles/hover = ExtResource("6_7vk7l")
+theme_override_styles/pressed = ExtResource("7_reiei")
+theme_override_styles/normal = ExtResource("5_axu5w")
+theme_override_fonts/font = ExtResource("4_g7kde")
+theme_override_font_sizes/font_size = 24
+text = "Yes"
+
+[node name="CancelButton" type="Button" parent="ConfirmRect/DialogPanel/VBoxContainer/ButtonHBox"]
+custom_minimum_size = Vector2(140, 40)
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0, 0, 1)
+theme_override_styles/disabled = ExtResource("8_imqog")
+theme_override_styles/hover = ExtResource("6_7vk7l")
+theme_override_styles/pressed = ExtResource("7_reiei")
+theme_override_styles/normal = ExtResource("5_axu5w")
+theme_override_fonts/font = ExtResource("4_g7kde")
+theme_override_font_sizes/font_size = 24
+text = "Cancel"
+
 [connection signal="value_changed" from="HBoxContainer/VBoxContainer/MusicSettingsRect/VBoxContainer/VolumeVbox/SoundLabel/SoundHScrollBar" to="HBoxContainer/VBoxContainer/MusicSettingsRect" method="_on_sound_h_scroll_bar_value_changed"]
 [connection signal="value_changed" from="HBoxContainer/VBoxContainer/MusicSettingsRect/VBoxContainer/VolumeVbox/MusicLabel/MusicHScrollBar" to="HBoxContainer/VBoxContainer/MusicSettingsRect" method="_on_music_h_scroll_bar_value_changed"]
 [connection signal="pressed" from="ButtonDone" to="." method="_on_ButtonDone_pressed"]
+[connection signal="pressed" from="MainMenuButton" to="." method="_on_MainMenuButton_pressed"]
+[connection signal="pressed" from="ConfirmRect/DialogPanel/VBoxContainer/ButtonHBox/YesButton" to="." method="_on_YesButton_pressed"]
+[connection signal="pressed" from="ConfirmRect/DialogPanel/VBoxContainer/ButtonHBox/CancelButton" to="." method="_on_CancelButton_pressed"]

--- a/src/scenes/UI/Main Menu/MainMenu.gd
+++ b/src/scenes/UI/Main Menu/MainMenu.gd
@@ -92,6 +92,7 @@ func _on_new_campaign_button_pressed():
 
 func _on_load_button_pressed():
 	loadgameCtrl.fill('',false)
+	loadgameCtrl.show()
 	loadgameWindow.show()
 
 


### PR DESCRIPTION
Adds a Main Menu button to the in-game settings panel with a styled confirm dialog. Also fixes two pre-existing save/load bugs surfaced by the new flow.

<img width="1144" height="645" alt="image" src="https://github.com/user-attachments/assets/773d9357-40b1-42bf-8c16-a1e4a1f4d224" />

<img width="1142" height="647" alt="image" src="https://github.com/user-attachments/assets/1893695d-3132-4a3e-a86c-b21d3f32593c" />
