### PR TITLE
Clean up startup errors and GDScript lint warnings

### DIFF
--- a/src/scenes/Map/TargetingLayer.gd
+++ b/src/scenes/Map/TargetingLayer.gd
@@ -53,8 +53,6 @@ var max_range : int = 0
 
 const OBSTRUCTEDTEXT : String = "Obstructed !"
 
-signal player_spell_confirmed
-
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -265,6 +263,7 @@ func _draw() :
 	var mousepos : Vector2i = Vector2i(map.get_local_mouse_position() ) #+ map.focuscharacter.get_pixel_position()
 #	var screensize : Vector2 = get_window().get_size()
 #	mousepos = mousepos -screensize/2 +Vector2(160,90)#- Vector2(320,180)
+	@warning_ignore("integer_division")
 	mousepos = mousepos/32
 #	mousepos = Vector2i(mousepos)
 #	var aoecolor : Color
@@ -419,7 +418,7 @@ func start_targ(tspell, tspellpower : int, tcaster : CombatCreaButton, _used_ite
 
 
 
-static func bresenham_line(startpt : Vector2, endpt : Vector2, min_range : int, max_range : int) -> Array :
+static func bresenham_line(startpt : Vector2, endpt : Vector2, min_range : int, p_max_range : int) -> Array :
 	# returns an array of all the tiles on the line between startpt and endpt, starting from startpt.
 	var returned : Array = []
 	
@@ -442,10 +441,9 @@ static func bresenham_line(startpt : Vector2, endpt : Vector2, min_range : int, 
 #	returned = [startpt, endpt]
 	if min_range>0 :
 		returned.pop_front()  # remove the tile where the user is !
-		# warning-ignore:narrowing_conversion
-		returned.resize(min(returned.size(),max_range))
+		returned.resize(min(returned.size(),p_max_range))
 	else :
-		returned.resize(min(returned.size(),max_range+1))
+		returned.resize(min(returned.size(),p_max_range+1))
 	if returned.is_empty() :
 		print("RETUNRED EMPTY !")
 	return returned
@@ -454,10 +452,8 @@ static func bresenham_line(startpt : Vector2, endpt : Vector2, min_range : int, 
 static func plotLineLow(startpt : Vector2, endpt : Vector2, reverseorder : bool) -> Array :
 	# bresenham for  |slope| <1
 	var returned : Array = []
-	# warning-ignore:narrowing_conversion
-	var dx : int = endpt.x - startpt.x
-	# warning-ignore:narrowing_conversion
-	var dy : int = endpt.y - startpt.y
+	var dx : int = int(endpt.x - startpt.x)
+	var dy : int = int(endpt.y - startpt.y)
 	var yi : int = 1
 	if dy < 0 :
 		yi = -1
@@ -480,10 +476,8 @@ static func plotLineLow(startpt : Vector2, endpt : Vector2, reverseorder : bool)
 static func plotLineHigh(startpt : Vector2, endpt : Vector2, reverseorder : bool) -> Array :
 	# bresenham for  |slope| >1
 	var returned : Array = []
-	# warning-ignore:narrowing_conversion
-	var dx : int = endpt.x - startpt.x
-	# warning-ignore:narrowing_conversion
-	var dy : int = endpt.y - startpt.y
+	var dx : int = int(endpt.x - startpt.x)
+	var dy : int = int(endpt.y - startpt.y)
 	var xi : int = 1
 	if dx < 0 :
 		xi = -1
@@ -509,7 +503,7 @@ func get_tiles_under_cb(cb : CombatCreaButton) -> Array :
 			returned_array.append(Vector2i(crea.position)+Vector2i(x,y))
 	return returned_array
 
-func get_affected_tiles(s_spell, s_power : int, s_caster : CombatCreaButton, s_targeted_pos : Vector2, s_aoe_override = []) ->Array :
+func get_affected_tiles(s_spell, s_power : int, s_caster : CombatCreaButton, s_targeted_pos : Vector2, _s_aoe_override = []) ->Array :
 	var s_max_range : int = s_spell.get_range(s_power, s_caster.creature)
 	var s_aoe_los = s_spell.los
 	var s_aoe_ray : bool = s_spell.ray
@@ -587,8 +581,8 @@ func get_cbs_touching_tiles(effected_tiles : Array) -> Array:
 #old gameglobal execute : (caster : CombatCreaButton,spell,power : int ,clickedtile : Vector2i, aoe_shape : Array, picked_targets : Dictionary, picked_tiles:Dictionary, chain_start : bool, must_add_terrain : bool) :
 #msg frmat : {"type" : "Spell", "caster" : Crea, "Effected Tiles" : [], "Effected creas" : [], "targeted_tiles" : [], "spell":GDScript, "s_plvl" : 1, "used_item" : null , "add_terrain" : true}
 
-func execute_spell(caster : CombatCreaButton,spell,power : int, trgt_tiles : Array, spell_used_item : Dictionary, must_add_terrain : bool, override_aoe : Array) :
-	#print("TargetingLayer execute_spell : "+spell.name+" trgt_tiles : ", trgt_tiles)
+func execute_spell(_caster : CombatCreaButton, s_spell, s_power : int, trgt_tiles : Array, spell_used_item : Dictionary, must_add_terrain : bool, override_aoe : Array) :
+	#print("TargetingLayer execute_spell : "+s_spell.name+" trgt_tiles : ", trgt_tiles)
 	#print("TargetingLayer aoe_shape ", aoe_shape)
-	var msg : Dictionary = {"type" : "Spell", "spell" : spell, "s_plvl" : power, "targeted_tiles" : trgt_tiles, "used_item" : spell_used_item , "must_add_terrain" : must_add_terrain, "override_aoe" : override_aoe }
+	var msg : Dictionary = {"type" : "Spell", "spell" : s_spell, "s_plvl" : s_power, "targeted_tiles" : trgt_tiles, "used_item" : spell_used_item , "must_add_terrain" : must_add_terrain, "override_aoe" : override_aoe }
 	StateMachine.state.on_spellcast_confirmed(msg)

--- a/src/scenes/MusicPlayer/MusicStreamPlayer.gd
+++ b/src/scenes/MusicPlayer/MusicStreamPlayer.gd
@@ -128,10 +128,10 @@ func play_music(musicdict: Dictionary) -> void:
 		if file:
 			var data = file.get_buffer(file.get_length())
 			file.close()
-			var stream = AudioStreamMPT.new()
-			stream.data = data
-			stream.loop_mode = 1  # Enable looping
-			set_stream(stream)
+			var mpt_stream = AudioStreamMPT.new()
+			mpt_stream.data = data
+			mpt_stream.loop_mode = 1  # Enable looping
+			set_stream(mpt_stream)
 			if musicdict["path"] == map_music_dict["path"]:
 				# TODO: Implement position saving for tracker files if needed
 				pass

--- a/src/scripts/AIScripts_functions.gd
+++ b/src/scripts/AIScripts_functions.gd
@@ -20,7 +20,7 @@ static func get_closest_creas_not_of_side(crea : Creature, notside : int) -> Arr
 	var found_range : int = 9999
 	for cb in StateMachine.combat_state.all_battle_creatures_btns :
 		if cb.creature.curFaction != notside :
-			var r : int = AiFunctions.get_range_between_creas(crea, cb.creature)
+			var r : int = get_range_between_creas(crea, cb.creature)
 			if r < found_range :
 				found_creas.clear()
 				found_range = r

--- a/src/scripts/Main.gd
+++ b/src/scripts/Main.gd
@@ -25,13 +25,10 @@ func _ready():
 	var setting_screen_size_x : float = Utils.FileHandler.get_cfg_setting(Paths.settingspath,"SETTINGS","screen_size_x", def_screen_size.x)
 	
 	var setting_screen_size_y : float = Utils.FileHandler.get_cfg_setting(Paths.settingspath,"SETTINGS","screen_size_y", def_screen_size.y)
-	printerr(setting_screen_size_x, ' ', setting_screen_size_y)
 	#setting_screen_size_x = 300
-	DisplayServer.window_set_size(Vector2(setting_screen_size_x,setting_screen_size_y))
-	
-	
-	
-	DisplayServer.window_set_max_size( DisplayServer.screen_get_size()-Vector2i(16,96) )
+	if not OS.has_feature("editor") :
+		DisplayServer.window_set_size(Vector2(setting_screen_size_x,setting_screen_size_y))
+		DisplayServer.window_set_max_size( DisplayServer.screen_get_size()-Vector2i(16,96) )
 	
 
 

--- a/src/scripts/game_state.gd
+++ b/src/scripts/game_state.gd
@@ -288,7 +288,7 @@ func check_map_script(position) ->bool :
 						num_of_poss_outcomes +=1
 					do_rr_fight = randi()%num_of_poss_outcomes==0
 					if do_rr_fight :
-						var battle_result = await ScriptHelperFuncs.do_RR_battle(sr["RR_Battle"])
+						var _battle_result = await ScriptHelperFuncsClass.do_RR_battle(sr["RR_Battle"])
 						if state==ex_menu_state :
 							print("StateMachine escape out of MenuState")
 							exit_ex_menu_state()

--- a/src/scripts/states/CbAnimationState.gd
+++ b/src/scripts/states/CbAnimationState.gd
@@ -37,7 +37,7 @@ func _ready():
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _process(_delta):
 	pass
 
 
@@ -87,7 +87,7 @@ func enter(_msg : Dictionary = {}) -> void:
 						print("CbAnim onmove extra_actions : ", extra_actions)
 						var xdiff : float = abs(GameGlobal.map.focuscharacter.tile_position_x-movercb.creature.position.x)
 						var ydiff : float = abs(GameGlobal.map.focuscharacter.tile_position_y-movercb.creature.position.y)
-						if combat_state.is_cam_too_far(xdiff,ydiff) :
+						if combat_state.is_cam_too_far(int(xdiff), int(ydiff)) :
 							GameGlobal.map.focuscharacter.set_tile_position(movercb.creature.position)
 						UI.ow_hud.updateCharPanelDisplay()
 						UI.ow_hud.creatureRect.display_crea_info(movercb)

--- a/src/scripts/states/CbDecideActionState.gd
+++ b/src/scripts/states/CbDecideActionState.gd
@@ -119,9 +119,9 @@ func initialize_battle(_msg :  Dictionary, _resources : CampaignResources, map :
 	combat_state.cur_battle_round = 0
 	combat_state.cur_battle_data = _msg
 	is_bandaging = false
-	var battle_pos : Array = [map.focuscharacter.tile_position_x, map.focuscharacter.tile_position_y]
+	var _battle_pos : Array = [map.focuscharacter.tile_position_x, map.focuscharacter.tile_position_y]
 	if _msg.has("Position") :
-		battle_pos = _msg["Position"]
+		_battle_pos = _msg["Position"]
 	UI.ow_hud.enter_battle_mode()
 	map.owcharacter.hide()
 	var ow_character =  map.owcharacter  #SO WE reset map.focuscharacter LATER ???

--- a/src/scripts/states/CbMenusState.gd
+++ b/src/scripts/states/CbMenusState.gd
@@ -7,8 +7,6 @@ var cur_menu_name : String = ''
 var picked_charapanels : Array = []
 var need_to_pick_n : int = 0
 
-signal characters_picked
-
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	pass

--- a/src/scripts/states/ExMenusState.gd
+++ b/src/scripts/states/ExMenusState.gd
@@ -239,7 +239,7 @@ func on_spell_picked(character : Creature, spell, powerlevel : int, _item : Dict
 			
 			if spell.get("special_effect") : 
 				print("FIELD SPECIAL EFFECT")
-				var is_over : bool = await spell.special_effect(character, spell, powerlevel, Vector2.ZERO, [], [target], false)
+				var _is_over : bool = await spell.special_effect(character, spell, powerlevel, Vector2.ZERO, [], [target], false)
 			
 			UI.ow_hud._on_spell_menu_closed()
 			UI.ow_hud.updateCharPanelDisplay()


### PR DESCRIPTION
Part 1 of cleaning up lint warnings so that we can work from a clean dev environment.

Removes a stray printerr in Main.gd, gates DisplayServer window-size calls so they only fire in exported builds (no more 'Embedded window can't be resized' errors), and clears 22 GDScript linter warnings across 8 scripts.