### PR TITLE
Clean up character small panel layout

### DIFF
--- a/src/scenes/UI/HUD/Characters Panel/CharacterSmallPanel.gd
+++ b/src/scenes/UI/HUD/Characters Panel/CharacterSmallPanel.gd
@@ -11,11 +11,10 @@ var paneltype : int = 0  #0=player character 1= NPC
 
 @onready var nameLabel : Label = $CharnameLabel
 @onready var faceButton : Button = $PortraitButton
-@onready var curHPLabel : Label= $"HPLabel/CurHPLabel"
-@onready var maxHPLabel : Label= $"HPLabel/MaxHPLabel"
-@onready var SPLabel : Label= $SPLabel
-@onready var curSPLabel : Label= $"SPLabel/CurSPLabel"
-@onready var maxSPLabel : Label= $"SPLabel/MaxSPLabel"
+@onready var HPLabel : Label = $HPLabel
+@onready var HPValueLabel : Label = $HPValueLabel
+@onready var SPLabel : Label = $SPLabel
+@onready var SPValueLabel : Label = $SPValueLabel
 
 @onready var selectButton : Button = $"SelectButton"
 @onready var selectedOffIcon : Texture2D = load("res://scenes/UI/HUD/Characters Panel/CharPanelSelectOff.png")
@@ -59,7 +58,6 @@ func set_character(chara : Creature) -> void :
 		faceButton.icon = chara.portrait
 	else :
 		faceButton.icon = chara.textureR
-	SPLabel.text = chara.used_resource 
 	bandead_sprite.frame = chara.life_status
 
 func set_type(t : int, showdropmenu : bool = true) :
@@ -100,21 +98,16 @@ func update_display() ->void :
 		faceButton.icon = character.portrait
 	else :
 		faceButton.icon = character.textureR
-	curHPLabel.text = str(character.get_stat("curHP"))
-	maxHPLabel.text = str(character.get_stat("maxHP"))
-	match character.used_resource :
-		"SP" :
-			curSPLabel.text = str( character.get_stat("curSP") )
-			maxSPLabel.text = str( character.get_stat("maxSP") )
-		"TP" :
-			curSPLabel.text = str( character.get_stat("curTP") )
-			maxSPLabel.text = str( character.get_stat("maxTP") )
-		"FP" :
-			curSPLabel.text = str( character.get_stat("curFP") )
-			maxSPLabel.text = str( character.get_stat("maxFP") )
-		"RP" :
-			curSPLabel.text = str( character.get_stat("curRP") )
-			maxSPLabel.text = str( character.get_stat("maxRP") )
+	HPValueLabel.text = "%d/%d" % [character.get_stat("curHP"), character.get_stat("maxHP")]
+	var resource_key : String = character.used_resource
+	var cur_key : String = "cur" + resource_key
+	var max_key : String = "max" + resource_key
+	if resource_key.is_empty() or not character.stats.has(cur_key) :
+		SPLabel.text = ""
+		SPValueLabel.text = ""
+	else :
+		SPLabel.text = resource_key
+		SPValueLabel.text = "%d/%d" % [character.get_stat(cur_key), character.get_stat(max_key)]
 	itemsnumberLabel.text = str(character.inventory.size())
 	curWeightLabel.text = str(character.get_inventory_weight())
 	maxWeightLabel.text = str(character.get_stat("Weight_Limit"))

--- a/src/scenes/UI/HUD/Characters Panel/CharacterSmallPanel.tscn
+++ b/src/scenes/UI/HUD/Characters Panel/CharacterSmallPanel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://5lpomncnwc17"]
+[gd_scene load_steps=15 format=3 uid="uid://5lpomncnwc17"]
 
 [ext_resource type="Texture2D" uid="uid://c7vufke0hme7f" path="res://scenes/UI/Main Menu/DefaultPortrait.png" id="1"]
 [ext_resource type="Texture2D" uid="uid://v6m7qkubvu1x" path="res://shared_assets/UI/StonePatternRect9.png" id="2"]
@@ -12,6 +12,7 @@
 [ext_resource type="StyleBox" uid="uid://wrrfixqq8c4o" path="res://shared_assets/UI/button_pressed_styleboxtexture.tres" id="10_sywfy"]
 [ext_resource type="StyleBox" uid="uid://c5gq8lv8robgu" path="res://shared_assets/UI/button_disabled_styleboxtexture.tres" id="11_g8sol"]
 [ext_resource type="PackedScene" uid="uid://b64nks77qjjwx" path="res://scenes/UI/HUD/Characters Panel/DropItemButton.tscn" id="12"]
+[ext_resource type="FontFile" path="res://Fonts/theldrowremake.ttf" id="13_theld"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_e33li"]
 
@@ -72,10 +73,11 @@ wait_time = 0.05
 
 [node name="CharnameLabel" type="Label" parent="."]
 layout_mode = 0
-offset_left = 67.2006
+offset_left = 67.0
 offset_top = 11.4013
-offset_right = 205.201
+offset_right = 197.0
 offset_bottom = 37.4013
+clip_text = true
 theme_override_colors/font_color = Color(1, 0.960784, 0, 1)
 theme_override_fonts/font = ExtResource("7_7ai5k")
 theme_override_font_sizes/font_size = 20
@@ -85,67 +87,45 @@ text = "Name"
 layout_mode = 0
 offset_left = 67.0
 offset_top = 37.0
-offset_right = 107.0
+offset_right = 87.0
 offset_bottom = 57.0
+theme_override_colors/font_color = Color(0.36, 0.84, 1, 1)
+theme_override_fonts/font = ExtResource("13_theld")
 theme_override_font_sizes/font_size = 12
-text = "HP :"
+text = "HP"
 
-[node name="CurHPLabel" type="Label" parent="HPLabel"]
+[node name="HPValueLabel" type="Label" parent="."]
 layout_mode = 0
-offset_left = 25.0
-offset_top = -4.0
-offset_right = 65.0
-offset_bottom = 22.0
-text = "9999"
-
-[node name="HPSlashLabel" type="Label" parent="HPLabel"]
-layout_mode = 0
-offset_left = 63.0
-offset_top = -4.0
-offset_right = 103.0
-offset_bottom = 22.0
-text = "/"
-
-[node name="MaxHPLabel" type="Label" parent="HPLabel"]
-layout_mode = 0
-offset_left = 71.0
-offset_top = -4.0
-offset_right = 111.0
-offset_bottom = 22.0
-text = "9999"
+offset_left = 87.0
+offset_top = 37.0
+offset_right = 132.0
+offset_bottom = 57.0
+theme_override_colors/font_color = Color(1, 0.960784, 0, 1)
+theme_override_fonts/font = ExtResource("13_theld")
+theme_override_font_sizes/font_size = 12
+text = "9999/9999"
 
 [node name="SPLabel" type="Label" parent="."]
 layout_mode = 0
-offset_left = 189.0
+offset_left = 135.0
 offset_top = 37.0
-offset_right = 229.0
+offset_right = 154.0
 offset_bottom = 57.0
+theme_override_colors/font_color = Color(0.36, 0.84, 1, 1)
+theme_override_fonts/font = ExtResource("13_theld")
 theme_override_font_sizes/font_size = 12
-text = "SP :"
+text = "SP"
 
-[node name="CurSPLabel" type="Label" parent="SPLabel"]
+[node name="SPValueLabel" type="Label" parent="."]
 layout_mode = 0
-offset_left = 24.0
-offset_top = -3.0
-offset_right = 64.0
-offset_bottom = 23.0
-text = "9999"
-
-[node name="SPSlashLabel" type="Label" parent="SPLabel"]
-layout_mode = 0
-offset_left = 68.0
-offset_top = -3.0
-offset_right = 108.0
-offset_bottom = 23.0
-text = "/"
-
-[node name="MaxSPLabel" type="Label" parent="SPLabel"]
-layout_mode = 0
-offset_left = 80.0
-offset_top = -3.0
-offset_right = 120.0
-offset_bottom = 23.0
-text = "9999"
+offset_left = 154.0
+offset_top = 37.0
+offset_right = 197.0
+offset_bottom = 57.0
+theme_override_colors/font_color = Color(1, 0.960784, 0, 1)
+theme_override_fonts/font = ExtResource("13_theld")
+theme_override_font_sizes/font_size = 12
+text = "9999/9999"
 
 [node name="SelectButton" type="Button" parent="."]
 layout_mode = 0

--- a/src/scenes/UI/HUD/OWHUDControl.tscn
+++ b/src/scenes/UI/HUD/OWHUDControl.tscn
@@ -226,9 +226,12 @@ texture = ExtResource("6")
 stretch_mode = 1
 
 [node name="CharScrollContainer" type="ScrollContainer" parent="VBoxScreen/HBoxTop/VBoxCharTime/CharactersRect"]
-layout_mode = 0
-offset_right = 320.0
-offset_bottom = 360.0
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 follow_focus = true
 scroll_deadzone = 60
 


### PR DESCRIPTION
Fixes overflowing HP/SP labels in the right-side character panels, restyles them to match the OG Realmz look (theldrowremake font, cyan stat label + yellow value), and removes the dead space below the scroll container so NPC allies are visible without scrolling.

Also fixes a latent crash: characters with `used_resource` not in (SP/TP/FP/RP) — e.g. MP — would crash on `get_stat()` lookup. Now handled defensively (label hidden if the resource keys aren't present).

Before:
<img width="1148" height="646" alt="image" src="https://github.com/user-attachments/assets/50323fc0-3360-48a6-9615-d020fd76e2e1" />

After: 
<img width="1145" height="647" alt="image" src="https://github.com/user-attachments/assets/5e0c44e0-64d8-4775-ad77-1ece17c26a92" />

With allies:
https://github.com/user-attachments/assets/8aed16fa-d729-4817-9763-bf15606e8e06