### PR TITLE
Automate version bump on merge to dev

### DIFF
--- a/.github/workflows/submit-dev.yml
+++ b/.github/workflows/submit-dev.yml
@@ -7,18 +7,49 @@ on:
 env:
   GODOT_VERSION: 4.3.0
   GODOT_VERSION_MAC_PI: 4.3
-  PROJECT_FILE: src/project.godot
-  VERSION_REGEX: config\/version=\"\K[0-9.\-A-z]*
   LFS_USERNAME: ${{secrets.LFS_USERNAME}}
   LFS_PASSWORD: ${{secrets.LFS_PASSWORD}}
   OPENMPT_VERSION: v1.3.2
 
 jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      new-version: ${{ steps.bump.outputs.new-version }}
+      new-sha: ${{ steps.bump.outputs.new-sha }}
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Bump patch version and push
+        id: bump
+        run: |
+          set -euo pipefail
+          OLD=$(grep -oP '^config/version="\K[^"]+' src/project.godot)
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$OLD"
+          NEW="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "Bumping ${OLD} -> ${NEW}"
+          sed -i "s|^config/version=\"${OLD}\"|config/version=\"${NEW}\"|" src/project.godot
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/project.godot
+          git commit -m "chore: bump version to ${NEW} [skip ci]"
+          git push origin dev
+          echo "new-version=${NEW}" >> "$GITHUB_OUTPUT"
+          echo "new-sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   build-macos:
+    needs: bump-version
     runs-on: macos-15-intel
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-version.outputs.new-sha }}
 
       - name: Configure Git LFS
         run: git config -f .lfsconfig lfs.url https://${{env.LFS_USERNAME}}:${{env.LFS_PASSWORD}}@git-lfs-s3-proxy-984.pages.dev/c8076907f522754d603bf3b68096609c.r2.cloudflarestorage.com/realmz-remake
@@ -76,10 +107,13 @@ jobs:
           project-dir: "./src"
 
   build-linux:
+    needs: bump-version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-version.outputs.new-sha }}
 
       - name: Configure Git LFS
         run: git config -f .lfsconfig lfs.url https://${{env.LFS_USERNAME}}:${{env.LFS_PASSWORD}}@git-lfs-s3-proxy-984.pages.dev/c8076907f522754d603bf3b68096609c.r2.cloudflarestorage.com/realmz-remake
@@ -137,10 +171,13 @@ jobs:
           project-dir: "./src"
 
   build-raspberry-pi:
+    needs: bump-version
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-version.outputs.new-sha }}
 
       - name: Configure Git LFS
         run: git config -f .lfsconfig lfs.url https://${{env.LFS_USERNAME}}:${{env.LFS_PASSWORD}}@git-lfs-s3-proxy-984.pages.dev/c8076907f522754d603bf3b68096609c.r2.cloudflarestorage.com/realmz-remake
@@ -195,10 +232,13 @@ jobs:
           project-dir: "./src"
 
   build-windows:
+    needs: bump-version
     runs-on: windows-latest
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-version.outputs.new-sha }}
 
       - name: Configure Git LFS
         run: git config -f .lfsconfig lfs.url https://${{env.LFS_USERNAME}}:${{env.LFS_PASSWORD}}@git-lfs-s3-proxy-984.pages.dev/c8076907f522754d603bf3b68096609c.r2.cloudflarestorage.com/realmz-remake
@@ -256,20 +296,15 @@ jobs:
           project-dir: "./src"
 
   generate-release:
-    needs: [build-windows, build-raspberry-pi, build-linux, build-macos]
+    needs: [bump-version, build-windows, build-raspberry-pi, build-linux, build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
-
-      - name: Extract version
-        uses: CapsCollective/version-actions/extract-version@v1.0
         with:
-          version-file: ${{ env.PROJECT_FILE }}
-          version-regex: ${{ env.VERSION_REGEX }}
-        id: extract-version
+          ref: ${{ needs.bump-version.outputs.new-sha }}
 
       - name: Download macOS artifact
         uses: actions/download-artifact@v4
@@ -298,8 +333,8 @@ jobs:
       - name: Tag and upload artifacts to release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.extract-version.outputs.version-string }}
-          commit: ${{ github.sha }}
+          tag: ${{ needs.bump-version.outputs.new-version }}
+          commit: ${{ needs.bump-version.outputs.new-sha }}
           allowUpdates: false
           artifactErrorsFailBuild: true
           prerelease: true

--- a/.github/workflows/verify-dev.yml
+++ b/.github/workflows/verify-dev.yml
@@ -7,46 +7,12 @@ on:
 env:
   GODOT_VERSION: 4.3.0
   GODOT_VERSION_MAC_PI: 4.3
-  PROJECT_FILE: src/project.godot
-  VERSION_REGEX: config\/version=\"\K[0-9.\-A-z]*
   LFS_USERNAME: ${{secrets.LFS_USERNAME}}
   LFS_PASSWORD: ${{secrets.LFS_PASSWORD}}
   OPENMPT_VERSION: v1.3.2
 
 jobs:
-  check-version-bump:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout current branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.base_ref }}
-
-      - name: Extract old version string
-        uses: CapsCollective/version-actions/extract-version@v1.0
-        with:
-          version-file: ${{ env.PROJECT_FILE }}
-          version-regex: ${{ env.VERSION_REGEX }}
-        id: extract-version-old
-
-      - name: Checkout current branch
-        uses: actions/checkout@v4
-
-      - name: Extract new version string
-        uses: CapsCollective/version-actions/extract-version@v1.0
-        with:
-          version-file: ${{ env.PROJECT_FILE }}
-          version-regex: ${{ env.VERSION_REGEX }}
-        id: extract-version-new
-
-      - name: Check semantic version bump
-        uses: CapsCollective/version-actions/check-version-bump@v1.0
-        with:
-          new-version: ${{ steps.extract-version-new.outputs.version-string }}
-          old-version: ${{ steps.extract-version-old.outputs.version-string }}
-
   # run-project-validation:
-  #   needs: check-version-bump
   #   runs-on: macos-13
   #   steps:
   #     - name: Checkout current branch
@@ -67,7 +33,6 @@ jobs:
   #       run: ${{ steps.install-godot.outputs.godot-executable }} --script scripts/run_validations.gd --headless
 
   build-macos:
-    needs: check-version-bump
     runs-on: macos-15-intel
     steps:
       - name: Checkout current branch
@@ -130,7 +95,6 @@ jobs:
           project-dir: "./src"
 
   build-linux:
-    needs: check-version-bump
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
@@ -193,7 +157,6 @@ jobs:
           project-dir: "./src"
 
   build-raspberry-pi:
-    needs: check-version-bump
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Checkout current branch
@@ -253,7 +216,6 @@ jobs:
           project-dir: "./src"
 
   build-windows:
-    needs: check-version-bump
     runs-on: windows-latest
     steps:
       - name: Checkout current branch

--- a/src/project.godot
+++ b/src/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Realmz"
-config/version="0.1.105"
+config/version="0.1.106"
 run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.6")
 boot_splash/bg_color=Color(0, 0, 0, 1)


### PR DESCRIPTION
## Summary

- Replace manual per-PR version bumping with a `bump-version` job that runs post-merge in `submit-dev.yml`. It increments `config/version` in `src/project.godot`, commits with `[skip ci]`, and exposes the new version + SHA as job outputs that build/release jobs consume.
- Remove the `check-version-bump` gate from `verify-dev.yml` and the `needs: check-version-bump` references on every build job — PR authors no longer touch the version.
- Last manual bump (0.1.105 → 0.1.106) included so this PR itself can pass the existing check before merging.

## Why

Today every PR has to manually bump `config/version` to satisfy `check-version-bump`, and the version field doubles as the GitHub Release tag emitted by `submit-dev.yml`. That makes the version a serializing token across all open PRs: two PRs branched at the same base both pick the next patch, whichever merges second has to rebase + re-bump. Long-lived branches silently rot the moment any other PR merges.

Folding the bump into `submit-dev.yml` post-merge removes the race entirely — the version is decided at merge time based on whatever dev currently is, and downstream PRs never see a version conflict.

## How it works

1. PR merges to dev (build jobs in `verify-dev.yml` already ran during PR review).
2. `submit-dev.yml` fires on the push. `bump-version` runs first: reads current version, increments patch, commits the bump back to dev with `[skip ci]` (prevents triggering another `submit-dev` run), and outputs `new-version` + `new-sha`.
3. `build-macos`, `build-linux`, `build-raspberry-pi`, `build-windows` all `needs: bump-version` and check out `${{ needs.bump-version.outputs.new-sha }}`, so their artifacts embed the bumped version.
4. `generate-release` tags the bumped commit with `${{ needs.bump-version.outputs.new-version }}`. The release commit and the tag's version field now agree, which the previous flow couldn't guarantee.

## Caveats — please verify before merging

- **Branch protection on `dev`**: this assumes `GITHUB_TOKEN` with `contents: write` can push directly to dev. If `dev` requires PRs / approvals / signed commits and doesn't grant a bypass to `github-actions[bot]`, the bump push will fail and `submit-dev` will fail post-merge. Two ways to address: add `github-actions[bot]` to a bypass rule, or switch to a PAT stored as a secret. Worth a quick check in repo settings before merging this PR.
- **Concurrent merges to dev**: GitHub generally serializes pushes, but if two `submit-dev` runs interleave their bump pushes, the second will reject with non-fast-forward. The current implementation has no rebase/retry. Acceptable for now (PRs to dev are infrequent), but a `git pull --rebase && git push` retry loop would harden it if it ever bites.
- **Release commit identity**: tag now points to the bot's bump commit rather than the merge commit. The bump commit is a direct child of the merge commit, so navigation back to the actual change is one click. Mentioning in case anyone relies on the prior behavior.

## Test plan

- [ ] Confirm `dev` branch protection allows `github-actions[bot]` to push (or set up a PAT secret named appropriately).
- [ ] After merge: a `submit-dev` run should appear, the `bump-version` job should commit `chore: bump version to 0.1.107 [skip ci]` to dev, build jobs should succeed against that SHA, and a `0.1.107` release should be created.
- [ ] Open a follow-up PR (e.g., rebase one of the currently-stuck spike branches) and confirm it no longer needs a manual bump and is no longer blocked by `check-version-bump`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)