### PR TITLE
Release on tag push, drop per-PR version-bump gate

### DIFF
--- a/.github/workflows/submit-dev.yml
+++ b/.github/workflows/submit-dev.yml
@@ -2,13 +2,12 @@ name: "Submit Dev"
 
 on:
   push:
-    branches: ["dev"]
+    branches: [dev]
+    tags: ['v*']
 
 env:
   GODOT_VERSION: 4.3.0
   GODOT_VERSION_MAC_PI: 4.3
-  PROJECT_FILE: src/project.godot
-  VERSION_REGEX: config\/version=\"\K[0-9.\-A-z]*
   LFS_USERNAME: ${{secrets.LFS_USERNAME}}
   LFS_PASSWORD: ${{secrets.LFS_PASSWORD}}
   OPENMPT_VERSION: v1.3.2
@@ -257,19 +256,13 @@ jobs:
 
   generate-release:
     needs: [build-windows, build-raspberry-pi, build-linux, build-macos]
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
-
-      - name: Extract version
-        uses: CapsCollective/version-actions/extract-version@v1.0
-        with:
-          version-file: ${{ env.PROJECT_FILE }}
-          version-regex: ${{ env.VERSION_REGEX }}
-        id: extract-version
 
       - name: Download macOS artifact
         uses: actions/download-artifact@v4
@@ -298,7 +291,7 @@ jobs:
       - name: Tag and upload artifacts to release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.extract-version.outputs.version-string }}
+          tag: ${{ github.ref_name }}
           commit: ${{ github.sha }}
           allowUpdates: false
           artifactErrorsFailBuild: true

--- a/.github/workflows/verify-dev.yml
+++ b/.github/workflows/verify-dev.yml
@@ -7,46 +7,12 @@ on:
 env:
   GODOT_VERSION: 4.3.0
   GODOT_VERSION_MAC_PI: 4.3
-  PROJECT_FILE: src/project.godot
-  VERSION_REGEX: config\/version=\"\K[0-9.\-A-z]*
   LFS_USERNAME: ${{secrets.LFS_USERNAME}}
   LFS_PASSWORD: ${{secrets.LFS_PASSWORD}}
   OPENMPT_VERSION: v1.3.2
 
 jobs:
-  check-version-bump:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout current branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.base_ref }}
-
-      - name: Extract old version string
-        uses: CapsCollective/version-actions/extract-version@v1.0
-        with:
-          version-file: ${{ env.PROJECT_FILE }}
-          version-regex: ${{ env.VERSION_REGEX }}
-        id: extract-version-old
-
-      - name: Checkout current branch
-        uses: actions/checkout@v4
-
-      - name: Extract new version string
-        uses: CapsCollective/version-actions/extract-version@v1.0
-        with:
-          version-file: ${{ env.PROJECT_FILE }}
-          version-regex: ${{ env.VERSION_REGEX }}
-        id: extract-version-new
-
-      - name: Check semantic version bump
-        uses: CapsCollective/version-actions/check-version-bump@v1.0
-        with:
-          new-version: ${{ steps.extract-version-new.outputs.version-string }}
-          old-version: ${{ steps.extract-version-old.outputs.version-string }}
-
   # run-project-validation:
-  #   needs: check-version-bump
   #   runs-on: macos-13
   #   steps:
   #     - name: Checkout current branch
@@ -67,7 +33,6 @@ jobs:
   #       run: ${{ steps.install-godot.outputs.godot-executable }} --script scripts/run_validations.gd --headless
 
   build-macos:
-    needs: check-version-bump
     runs-on: macos-15-intel
     steps:
       - name: Checkout current branch
@@ -130,7 +95,6 @@ jobs:
           project-dir: "./src"
 
   build-linux:
-    needs: check-version-bump
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
@@ -193,7 +157,6 @@ jobs:
           project-dir: "./src"
 
   build-raspberry-pi:
-    needs: check-version-bump
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Checkout current branch
@@ -253,7 +216,6 @@ jobs:
           project-dir: "./src"
 
   build-windows:
-    needs: check-version-bump
     runs-on: windows-latest
     steps:
       - name: Checkout current branch

--- a/src/project.godot
+++ b/src/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Realmz"
-config/version="0.1.105"
+config/version="0.1.106"
 run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.6")
 boot_splash/bg_color=Color(0, 0, 0, 1)


### PR DESCRIPTION
## TL;DR

Drop the per-PR version-bump requirement and gate GitHub Release creation on tag pushes (`v*`) instead of every dev merge. Per-merge builds still run on every merge — bisect-friendly artifacts remain available via the Actions tab.

## Changes

- `verify-dev.yml`: delete `check-version-bump` job and its 4 `needs:` references.
- `submit-dev.yml`: keep `push: branches: [dev]`, add `push: tags: ['v*']`. Gate `generate-release` on `if: startsWith(github.ref, 'refs/tags/v')` so it only runs on tag push. Tag value becomes `${{ github.ref_name }}` (drops the `Extract version` step).
- `src/project.godot`: 0.1.105 → 0.1.106, last manual bump to satisfy the existing check on this PR.

3 files changed, 5 insertions, 50 deletions.

## How releases work after this

Per-merge builds upload artifacts as today (retrievable from the Actions tab — same pages contributors already use). To cut a real release:

```bash
git tag v0.1.107 && git push origin v0.1.107
```

That tag push fires `submit-dev.yml`, builds all four platforms, and creates a GitHub Release named `v0.1.107` from the tagged commit.

## Addressing the bisect concern

Build artifacts continue to upload on every merge to dev via the existing `actions/upload-artifact` calls in each `build-godot-*` action. They're retrievable from the workflow run page for each merge (default 90-day retention). Bisecting build regressions still works — just via the Actions tab rather than the Releases page.

## Test plan

- [ ] Merge this PR → `submit-dev` fires on the dev push, build jobs run, no GitHub Release created.
- [ ] `git tag v0.1.107 && git push origin v0.1.107` → `submit-dev` fires, builds, and creates a `v0.1.107` Release.
- [ ] Open a follow-up PR → no version-bump requirement, not gated on `check-version-bump`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)