### PR TITLE
Redesign in-game character stat screen + bestiary

### DIFF
--- a/src/project.godot
+++ b/src/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Realmz"
-config/version="0.1.105"
+config/version="0.1.107"
 run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.6")
 boot_splash/bg_color=Color(0, 0, 0, 1)

--- a/src/scenes/UI/HUD/Bestiary/bestiary_rect.gd
+++ b/src/scenes/UI/HUD/Bestiary/bestiary_rect.gd
@@ -1,384 +1,68 @@
 extends NinePatchRect
 
-@export var button_tscn : PackedScene  #"res://scenes/UI/HUD/Bestiary/bestiary_button.tscn"
+# Creature browser. Hosts the creature list (left) plus a CreatureInfoPanel
+# (right) that handles the actual stat/resist/abilities/lore display. Selecting
+# a creature button calls info_panel.populate(cdata). Closing the panel hides
+# the bestiary entirely.
 
-@export var listrect : Control
+@export var button_tscn : PackedScene  # res://scenes/UI/HUD/Bestiary/bestiary_button.tscn
+
 @export var entrycontainer : VBoxContainer
 @export var search_lineedit : LineEdit
-
-@export var portrait_texrect : TextureRect
-@export var portrait_lvl_label : Label
-@export var name_label : Label
-@export var subtitle_label : Label
-@export var hp_label : Label
-@export var sp_label : Label
-
-@export var stats_grid : GridContainer
-@export var resists_grid : GridContainer
-
-@export var tags_header : Label
-@export var tags_label : Label
-@export var special_grid : GridContainer
-@export var abil_spacer : Control
-@export var abilities_header : Label
-@export var abilities_label : Label
-@export var descr_label : Label
-@export var close_button : Button
-
-const COLOR_HEADER : Color = Color(1, 0.98, 0, 1)
-const COLOR_LABEL : Color = Color(0.85, 0.85, 0.85, 1)
-const COLOR_VALUE : Color = Color(1, 1, 1, 1)
-const COLOR_DIM : Color = Color(0.65, 0.65, 0.65, 1)
-const COLOR_GOOD : Color = Color(0.55, 0.85, 0.55, 1)
-const COLOR_BAD : Color = Color(1, 0.5, 0.5, 1)
-const COLOR_SHADOW : Color = Color(0, 0, 0, 1)
-
-const STAT_ROWS : Array = [
-	["Movement", "MaxMovement"],
-	["Actions / Round", "MaxActions"],
-	["Weight Limit", "Weight_Limit"],
-	["Strength", "Strength"],
-	["Intellect", "Intellect"],
-	["Wisdom", "Wisdom"],
-	["Dexterity", "Dexterity"],
-	["Vitality", "Vitality"],
-	["Max HP", "maxHP"],
-	["HP Regen", "HP_regen_base"],
-	["Max SP", "maxSP"],
-	["SP Regen", "SP_regen_base"],
-	["Acc · Melee", "AccuracyMelee"],
-	["Eva · Melee", "EvasionMelee"],
-	["Acc · Ranged", "AccuracyRanged"],
-	["Eva · Ranged", "EvasionRanged"],
-	["Acc · Magic", "AccuracyMagic"],
-	["Eva · Magic", "EvasionMagic"],
-]
-
-const RESIST_ROWS : Array = [
-	["Physical", "Physical"],
-	["Magic", "Magic"],
-	["Mental", "Mental"],
-	["Healing", "Healing"],
-	["Fire", "Fire"],
-	["Ice", "Ice"],
-	["Electric", "Elect"],
-	["Poison", "Poison"],
-	["Disease", "Disease"],
-	["Chemical", "Chemical"],
-]
+@export var info_panel : CreatureInfoPanel
 
 var _list_seeded : bool = false
-var _expanded : bool = false
-var _original_parent : Node = null
-var _original_index : int = -1
+var _selected_button : Button = null
+
+
+func _ready() :
+	if info_panel != null :
+		info_panel.close_requested.connect(_on_close_requested)
+	visibility_changed.connect(_on_visibility_changed)
 
 
 func _initialize() :
-	set_character_mode(false)
 	if _list_seeded :
 		return
 	var book = NodeAccess.__Resources().crea_book
+	var first_button : Button = null
 	for c in book :
 		if book[c]["data"]["in_bestiary"] > 0 :
 			var nb = button_tscn.instantiate()
 			nb.set_creature(book[c])
 			entrycontainer.add_child(nb)
-			nb.connect("pressed", Callable(self, "_on_entry_pressed").bind(nb.cdata))
+			nb.connect("pressed", Callable(self, "_on_entry_pressed").bind(nb))
+			if first_button == null :
+				first_button = nb
 	_list_seeded = true
+	if first_button != null :
+		_select_button(first_button)
 
 
-func show_for_character(cdata) -> void :
-	set_character_mode(true)
-	_on_entry_pressed(cdata)
-	show()
+func _on_entry_pressed(button : Button) -> void :
+	_select_button(button)
 
 
-# Toggle "character" view (full-screen, no list) vs "bestiary" view (default).
-# Public so OWHUDControl can reset this when opening the bestiary normally.
-func set_character_mode(enabled : bool) -> void :
-	if enabled :
-		_enter_expanded()
-		listrect.hide()
-	else :
-		_exit_expanded()
-		listrect.show()
+func _select_button(button : Button) -> void :
+	_selected_button = button
+	if info_panel != null :
+		info_panel.populate(button.cdata)
 
 
-# In expanded mode we reparent to the HUD root so we draw on top of HBoxBot,
-# rather than hiding TextRect/CreatureRect (which reflows HBoxBot and pushes
-# BotRightPanel under us).
-func _enter_expanded() -> void :
-	if _expanded :
+func _on_visibility_changed() -> void :
+	if not visible :
 		return
-	_expanded = true
-	var hud = UI.ow_hud
-	var hud_size : Vector2 = hud.size if hud else Vector2(1152, 648)
-	_original_parent = get_parent()
-	_original_index = get_index()
-	var parent_w : float = _original_parent.size.x if _original_parent else 832.0
-	if hud and _original_parent != hud :
-		_original_parent.remove_child(self)
-		hud.add_child(self)
-	top_level = true
-	set_anchors_and_offsets_preset(Control.PRESET_TOP_LEFT)
-	position = Vector2.ZERO
-	size = Vector2(parent_w, hud_size.y)
-
-
-func _exit_expanded() -> void :
-	if not _expanded :
+	if _selected_button == null or not is_instance_valid(_selected_button) :
 		return
-	_expanded = false
-	top_level = false
-	if _original_parent != null and get_parent() != _original_parent :
-		get_parent().remove_child(self)
-		_original_parent.add_child(self)
-		if _original_index >= 0 :
-			_original_parent.move_child(self, _original_index)
-	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	_original_parent = null
-	_original_index = -1
+	# Wait a frame for layout to settle (especially when the bestiary was just
+	# made visible — ScrollContainer needs valid sizes to scroll correctly).
+	var scroll = entrycontainer.get_parent()
+	if scroll is ScrollContainer :
+		await get_tree().process_frame
+		scroll.ensure_control_visible(_selected_button)
 
 
-func _on_entry_pressed(cdata) -> void :
-	var data : Dictionary = cdata.get("data", {})
-	var stats : Dictionary = cdata.get("stats", {})
-	var tools : Dictionary = cdata.get("tools", {})
-
-	name_label.text = str(data.get("name", "Unknown"))
-
-	var lvl : int = int(data.get("level", 1))
-	portrait_lvl_label.text = "Lv %d" % lvl
-
-	var img = data.get("image", null)
-	if img != null :
-		portrait_texrect.texture = img
-
-	# Subtitle: explicit override (e.g. "Gnome Warlock") wins; else fall back to
-	# "Level X · first-tag" for creatures.
-	var tags : Array = data.get("tags", [])
-	var subtitle_override = data.get("subtitle", null)
-	if subtitle_override != null and not str(subtitle_override).is_empty() :
-		subtitle_label.text = "Level %d · %s" % [lvl, str(subtitle_override)]
-	else :
-		var subtitle_parts : Array = ["Level %d" % lvl]
-		if tags.size() > 0 :
-			subtitle_parts.append(str(tags[0]))
-		subtitle_label.text = " · ".join(subtitle_parts)
-
-	# HP / SP
-	var max_hp : int = int(stats.get("maxHP", 0))
-	var max_sp : int = int(stats.get("maxSP", 0))
-	hp_label.text = "HP %d" % max_hp
-	sp_label.text = "SP %d" % max_sp
-
-	_rebuild_stats_grid(stats)
-	_rebuild_resists_grid(stats)
-	_populate_aux_panel(cdata, tags, tools)
-
-	descr_label.text = str(data.get("description", ""))
-
-
-# The bottom-left panel shows TAGS+ABILITIES for creatures, or SPECIAL SKILLS
-# for player characters when cdata["special_skills"] is provided.
-func _populate_aux_panel(cdata, tags : Array, tools : Dictionary) -> void :
-	var special_skills : Array = cdata.get("special_skills", [])
-	if special_skills.size() > 0 :
-		tags_header.text = "SPECIAL SKILLS"
-		tags_label.hide()
-		abil_spacer.hide()
-		abilities_header.hide()
-		abilities_label.hide()
-		_rebuild_special_grid(special_skills)
-		special_grid.show()
-		return
-
-	special_grid.hide()
-	tags_label.show()
-	tags_header.text = "TAGS"
-	if tags.is_empty() :
-		tags_label.text = "—"
-	else :
-		tags_label.text = ", ".join(tags.map(func(t): return str(t)))
-	abil_spacer.show()
-	abilities_header.show()
-	abilities_label.show()
-	var abilities : Array = tools.get("spells", [])
-	if abilities.is_empty() :
-		abilities_label.text = "—"
-	else :
-		var parts : Array = []
-		for s in abilities :
-			parts.append("%s (Lv %s)" % [s[0], s[1]])
-		abilities_label.text = ", ".join(parts)
-
-
-func _rebuild_special_grid(skills : Array) -> void :
-	for c in special_grid.get_children() :
-		c.queue_free()
-	for entry in skills :
-		var name_lbl := Label.new()
-		name_lbl.text = str(entry[0])
-		name_lbl.add_theme_font_size_override("font_size", 13)
-		name_lbl.add_theme_color_override("font_color", COLOR_LABEL)
-		name_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		name_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
-		special_grid.add_child(name_lbl)
-
-		var val_str : String = str(entry[1])
-		var val_lbl := Label.new()
-		val_lbl.text = val_str
-		val_lbl.add_theme_font_size_override("font_size", 13)
-		val_lbl.add_theme_color_override("font_color", _color_for_signed_str(val_str))
-		val_lbl.custom_minimum_size = Vector2(72, 0)
-		val_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-		special_grid.add_child(val_lbl)
-
-
-# Color positive/negative formatted strings (e.g. "+12.5%" -> green, "-3" -> red).
-func _color_for_signed_str(s : String) -> Color :
-	if s.begins_with("-") :
-		return COLOR_BAD
-	if s.begins_with("+") :
-		return COLOR_GOOD
-	return COLOR_VALUE
-
-
-func _rebuild_stats_grid(stats : Dictionary) -> void :
-	for c in stats_grid.get_children() :
-		c.queue_free()
-	for row in STAT_ROWS :
-		_add_stat_cell(row[0], false)
-		_add_stat_cell(_format_stat(stats.get(row[1], 0)), true)
-
-
-func _add_stat_cell(text : String, is_value : bool) -> void :
-	var lbl := Label.new()
-	lbl.text = text
-	lbl.add_theme_font_size_override("font_size", 13)
-	lbl.add_theme_color_override("font_shadow_color", COLOR_SHADOW)
-	lbl.add_theme_constant_override("shadow_offset_x", 1)
-	lbl.add_theme_constant_override("shadow_offset_y", 1)
-	if is_value :
-		lbl.add_theme_color_override("font_color", COLOR_VALUE)
-		lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
-	else :
-		lbl.add_theme_color_override("font_color", COLOR_LABEL)
-		lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-	stats_grid.add_child(lbl)
-
-
-func _rebuild_resists_grid(stats : Dictionary) -> void :
-	for c in resists_grid.get_children() :
-		c.queue_free()
-
-	# Column header row
-	_add_resist_header("TYPE", HORIZONTAL_ALIGNMENT_LEFT)
-	_add_resist_header("RES", HORIZONTAL_ALIGNMENT_RIGHT)
-	_add_resist_header("MULT", HORIZONTAL_ALIGNMENT_RIGHT)
-
-	for row in RESIST_ROWS :
-		var display_name : String = row[0]
-		var key : String = row[1]
-		var res_val = stats.get("Resistance" + key, 0)
-		var mult_val = stats.get("Multiplier" + key, 1.0)
-		_add_resist_label(display_name, COLOR_LABEL, HORIZONTAL_ALIGNMENT_LEFT)
-		_add_resist_value(_format_resist_pct(res_val), _color_for_resist(res_val), HORIZONTAL_ALIGNMENT_RIGHT)
-		_add_resist_value(_format_mult(mult_val), _color_for_mult(mult_val), HORIZONTAL_ALIGNMENT_RIGHT)
-
-
-func _add_resist_header(text : String, align : int) -> void :
-	var lbl := Label.new()
-	lbl.text = text
-	lbl.add_theme_font_size_override("font_size", 11)
-	lbl.add_theme_color_override("font_color", COLOR_DIM)
-	lbl.add_theme_color_override("font_shadow_color", COLOR_SHADOW)
-	lbl.add_theme_constant_override("shadow_offset_x", 1)
-	lbl.add_theme_constant_override("shadow_offset_y", 1)
-	lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	lbl.horizontal_alignment = align
-	resists_grid.add_child(lbl)
-
-
-func _add_resist_label(text : String, color : Color, align : int) -> void :
-	var lbl := Label.new()
-	lbl.text = text
-	lbl.add_theme_font_size_override("font_size", 13)
-	lbl.add_theme_color_override("font_color", color)
-	lbl.add_theme_color_override("font_shadow_color", COLOR_SHADOW)
-	lbl.add_theme_constant_override("shadow_offset_x", 1)
-	lbl.add_theme_constant_override("shadow_offset_y", 1)
-	lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	lbl.horizontal_alignment = align
-	resists_grid.add_child(lbl)
-
-
-func _add_resist_value(text : String, color : Color, align : int) -> void :
-	var lbl := Label.new()
-	lbl.text = text
-	lbl.add_theme_font_size_override("font_size", 13)
-	lbl.add_theme_color_override("font_color", color)
-	lbl.add_theme_color_override("font_shadow_color", COLOR_SHADOW)
-	lbl.add_theme_constant_override("shadow_offset_x", 1)
-	lbl.add_theme_constant_override("shadow_offset_y", 1)
-	lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	lbl.horizontal_alignment = align
-	resists_grid.add_child(lbl)
-
-
-func _format_stat(v) -> String :
-	if v is float :
-		# Drop trailing zeros: 1.00 -> 1, 1.06 -> 1.06.
-		var s : String = "%.2f" % v
-		if "." in s :
-			s = s.rstrip("0").rstrip(".")
-			if s == "" or s == "-" :
-				s = "0"
-		return s
-	return str(v)
-
-
-func _format_resist_pct(v) -> String :
-	var f : float = float(v)
-	if abs(f) < 0.005 :
-		return "0"
-	return "%d%%" % int(round(f * 100.0)) if abs(f) < 1.5 else "%d" % int(round(f))
-
-
-func _format_mult(v) -> String :
-	var f : float = float(v)
-	if abs(f - 1.0) < 0.005 :
-		# Default multiplier (no modifier) — render blank to avoid visual noise.
-		return ""
-	# Show 2 decimals trimmed.
-	var s : String = "%.2f" % f
-	if "." in s :
-		s = s.rstrip("0").rstrip(".")
-	return "×" + s
-
-
-func _color_for_resist(v) -> Color :
-	var f : float = float(v)
-	if f > 0.005 :
-		return COLOR_GOOD
-	if f < -0.005 :
-		return COLOR_BAD
-	return COLOR_DIM
-
-
-func _color_for_mult(v) -> Color :
-	var f : float = float(v)
-	if f < 1.0 - 0.005 :
-		return COLOR_GOOD
-	if f > 1.0 + 0.005 :
-		return COLOR_BAD
-	return COLOR_DIM
-
-
-func _on_close_button_pressed() -> void :
-	set_character_mode(false)
+func _on_close_requested() -> void :
 	hide()
 	StateMachine.transition_to("Exploration/ExWalking")
 

--- a/src/scenes/UI/HUD/Bestiary/bestiary_rect.gd
+++ b/src/scenes/UI/HUD/Bestiary/bestiary_rect.gd
@@ -11,6 +11,9 @@ extends NinePatchRect
 @export var search_lineedit : LineEdit
 @export var info_panel : CreatureInfoPanel
 
+const SELECTED_MODULATE : Color = Color(1.2, 1.15, 0.7, 1)
+const UNSELECTED_MODULATE : Color = Color(1, 1, 1, 1)
+
 var _list_seeded : bool = false
 var _selected_button : Button = null
 
@@ -44,7 +47,10 @@ func _on_entry_pressed(button : Button) -> void :
 
 
 func _select_button(button : Button) -> void :
+	if _selected_button != null and is_instance_valid(_selected_button) :
+		_selected_button.modulate = UNSELECTED_MODULATE
 	_selected_button = button
+	button.modulate = SELECTED_MODULATE
 	if info_panel != null :
 		info_panel.populate(button.cdata)
 

--- a/src/scenes/UI/HUD/Bestiary/bestiary_rect.gd
+++ b/src/scenes/UI/HUD/Bestiary/bestiary_rect.gd
@@ -1,137 +1,389 @@
 extends NinePatchRect
-#BestiaryRect
 
 @export var button_tscn : PackedScene  #"res://scenes/UI/HUD/Bestiary/bestiary_button.tscn"
 
-@onready var entrycontainer = $HBoxContainer/ListRect/VBoxContainer/ListControl/ScrollContainer/EntryContainer
+@export var listrect : Control
+@export var entrycontainer : VBoxContainer
+@export var search_lineedit : LineEdit
 
-@onready var nameLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/LoreRect/NameLabel
-@onready var descrLabel : Label =$HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/LoreRect/DescrLabel
-@onready var texRect : TextureRect = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/LoreRect/NinePatchRect/TextureRect
-@onready var lvlLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/LoreRect/NinePatchRect/LvlLabel
-@onready var tagsLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/AbilitiesRect/TagsLabel2
-@onready var abilitiesLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/AbilitiesRect/AbilitiesLabel2
+@export var portrait_texrect : TextureRect
+@export var portrait_lvl_label : Label
+@export var name_label : Label
+@export var subtitle_label : Label
+@export var hp_label : Label
+@export var sp_label : Label
 
-@onready var physresLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN1/PhysResnLabel
-@onready var physmultLabel: Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM1/PhysMultnLabel
-@onready var magiresLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN1/MagiResnLabel
-@onready var magimultLabel: Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM1/MagiMultnLabel
-@onready var healresLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN1/HealResnLabel
-@onready var healmultLabel: Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM1/HealMultLabel
-@onready var mentresLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN1/MentResnLabel
-@onready var mentmultLabel: Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM1/MentMultLabel
-@onready var fireresLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN2/FireResnLabel
-@onready var firemultLabel: Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM2/FireMultnLabel 
-@onready var iceresLabel  : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN2/IceResnLabel
-@onready var icemultLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM2/IceMultnLabel
-@onready var elecresLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN2/ElecResnLabel
-@onready var elecmultLabel: Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM2/ElecMultLabel
-@onready var poisresLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN3/PosnResnLabel
-@onready var poismultLabel: Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM3/PoisMultnLabel
-@onready var dissresLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN3/DissResnLabel
-@onready var dissmultLabel: Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM3/DissMultnLabel
-@onready var chemresLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN3/ChemResnLabel
-@onready var chemmultLabel: Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM3/ChemMultnLabel
+@export var stats_grid : GridContainer
+@export var resists_grid : GridContainer
 
-@onready var moveLabel : Label = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox2/MovementnLabel
-@onready var APRLabel : Label  = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox2/APRnLabel
-@onready var dmgLabel : Label  = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox2/DamagenLabel
-@onready var HPLabel : Label   = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox4/HPnLabel
-@onready var SPLabel : Label   = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox4/SPnLabel
-@onready var HPrLabel : Label   = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox4/HPrnLabel
-@onready var SPrLabel : Label   = $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox4/SPrnLabel
-@onready var accmeleeLabel : Label =  $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox6/AccMeleenLabel
-@onready var accrangeLabel : Label =  $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox6/AccRangenLabel
-@onready var accmagicLabel : Label =  $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox6/AccMagicnLabel
-@onready var evameleeLabel : Label =  $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox8/EvaMeleenLabel
-@onready var evarangeLabel : Label =  $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox8/EvaRangenLabel
-@onready var evamagicLabel : Label =  $HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox8/EvaMagicnLabel
+@export var tags_header : Label
+@export var tags_label : Label
+@export var special_grid : GridContainer
+@export var abil_spacer : Control
+@export var abilities_header : Label
+@export var abilities_label : Label
+@export var descr_label : Label
+@export var close_button : Button
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass # Replace with function body.
+const COLOR_HEADER : Color = Color(1, 0.98, 0, 1)
+const COLOR_LABEL : Color = Color(0.85, 0.85, 0.85, 1)
+const COLOR_VALUE : Color = Color(1, 1, 1, 1)
+const COLOR_DIM : Color = Color(0.65, 0.65, 0.65, 1)
+const COLOR_GOOD : Color = Color(0.55, 0.85, 0.55, 1)
+const COLOR_BAD : Color = Color(1, 0.5, 0.5, 1)
+const COLOR_SHADOW : Color = Color(0, 0, 0, 1)
 
+const STAT_ROWS : Array = [
+	["Movement", "MaxMovement"],
+	["Actions / Round", "MaxActions"],
+	["Weight Limit", "Weight_Limit"],
+	["Strength", "Strength"],
+	["Intellect", "Intellect"],
+	["Wisdom", "Wisdom"],
+	["Dexterity", "Dexterity"],
+	["Vitality", "Vitality"],
+	["Max HP", "maxHP"],
+	["HP Regen", "HP_regen_base"],
+	["Max SP", "maxSP"],
+	["SP Regen", "SP_regen_base"],
+	["Acc · Melee", "AccuracyMelee"],
+	["Eva · Melee", "EvasionMelee"],
+	["Acc · Ranged", "AccuracyRanged"],
+	["Eva · Ranged", "EvasionRanged"],
+	["Acc · Magic", "AccuracyMagic"],
+	["Eva · Magic", "EvasionMagic"],
+]
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta):
-#	pass
+const RESIST_ROWS : Array = [
+	["Physical", "Physical"],
+	["Magic", "Magic"],
+	["Mental", "Mental"],
+	["Healing", "Healing"],
+	["Fire", "Fire"],
+	["Ice", "Ice"],
+	["Electric", "Elect"],
+	["Poison", "Poison"],
+	["Disease", "Disease"],
+	["Chemical", "Chemical"],
+]
+
+var _list_seeded : bool = false
+var _expanded : bool = false
+var _original_parent : Node = null
+var _original_index : int = -1
+
 
 func _initialize() :
+	set_character_mode(false)
+	if _list_seeded :
+		return
 	var book = NodeAccess.__Resources().crea_book
 	for c in book :
-		if book[c]["data"]["in_bestiary"]>0 :
+		if book[c]["data"]["in_bestiary"] > 0 :
 			var nb = button_tscn.instantiate()
 			nb.set_creature(book[c])
 			entrycontainer.add_child(nb)
-			nb.connect("pressed", Callable(self,"_on_entry_pressed").bind(nb.cdata))
+			nb.connect("pressed", Callable(self, "_on_entry_pressed").bind(nb.cdata))
+	_list_seeded = true
 
-func _on_entry_pressed(cdata) :
-#	print(cdata)
-	nameLabel.text = str( cdata["data"]["name"] )
-	descrLabel.text = str( cdata["data"]["description"] )
-	lvlLabel.text = "Level "+str( cdata["data"]["level"] )
-	texRect.texture = cdata["data"]["image"]
-	var sizev = cdata["data"]["image"].get_image().get_size()
-	texRect.size = sizev
-	texRect.position.x = 35-sizev.x/2
-	texRect.position.y = 35-sizev.y/2
-	
-	var tags : Array = cdata["data"]["tags"]
-	var tagstext : String = ''
-	for t in tags :
-		tagstext += t + ', '
-	tagstext.trim_suffix(', ')
-	tagsLabel.text = tagstext
-	var abilities : Array = cdata["tools"]["spells"]
-	var abilitiestext : String = ''
-	for s in abilities :
-		abilitiestext += s[0] + ' lvl'+str(s[1])+', '
-	abilitiestext.trim_suffix(', ')
-	abilitiesLabel.text = abilitiestext
-	
-	physresLabel.text = str( cdata["stats"]["ResistancePhysical"] )
-	physmultLabel.text = str( cdata["stats"]["MultiplierPhysical"] )
-	magiresLabel.text = str( cdata["stats"]["ResistanceMagic" ] )
-	magimultLabel.text = str( cdata["stats"]["MultiplierMagic" ] )
-	healresLabel.text = str( cdata["stats"]["ResistanceHealing" ] )
-	healmultLabel.text = str( cdata["stats"]["MultiplierHealing" ] )
-	mentresLabel.text = str( cdata["stats"]["ResistanceMental" ] )
-	mentmultLabel.text = str( cdata["stats"]["MultiplierMental"] )
 
-	fireresLabel.text = str( cdata["stats"]["ResistanceFire"] )
-	firemultLabel.text= str( cdata["stats"]["MultiplierFire"] )
-	iceresLabel.text = str( cdata["stats"]["ResistanceIce"] )
-	icemultLabel.text= str( cdata["stats"]["MultiplierIce"] )
-	elecresLabel.text = str( cdata["stats"]["ResistanceElect"] )
-	elecmultLabel.text= str( cdata["stats"]["MultiplierElect"] )
+func show_for_character(cdata) -> void :
+	set_character_mode(true)
+	_on_entry_pressed(cdata)
+	show()
 
-	poisresLabel.text = str( cdata["stats"]["ResistancePoison"] )
-	poismultLabel.text= str( cdata["stats"]["MultiplierPoison"] )
-	dissresLabel.text = str( cdata["stats"]["ResistanceDisease" ] )
-	dissmultLabel.text= str( cdata["stats"]["MultiplierDisease"] )
-	chemresLabel.text = str( cdata["stats"]["ResistanceChemical"] )
-	chemmultLabel.text= str( cdata["stats"]["MultiplierChemical"] )
 
-	moveLabel.text= str( cdata["stats"]["MaxMovement" ] )
-	APRLabel.text= str( cdata["stats"]["MaxActions"] )
-	dmgLabel.text= "NA"
-	HPLabel.text= str( cdata["stats"]["maxHP"] )
-	SPLabel.text= str( cdata["stats"]["maxSP"] )
-	HPrLabel.text= str( cdata["stats"]["HP_regen_base" ] )
-	SPrLabel.text= str( cdata["stats"]["SP_regen_base" ] )
-	accmeleeLabel.text= str( cdata["stats"]["AccuracyMelee" ] )
-	accrangeLabel.text= str( cdata["stats"]["AccuracyRanged" ] )
-	accmagicLabel.text= str( cdata["stats"]["AccuracyMagic" ] )
-	evameleeLabel.text= str( cdata["stats"]["EvasionMelee"] )
-	evarangeLabel.text= str( cdata["stats"]["EvasionRanged" ] )
-	evamagicLabel.text= str( cdata["stats"]["EvasionMagic" ] )
+# Toggle "character" view (full-screen, no list) vs "bestiary" view (default).
+# Public so OWHUDControl can reset this when opening the bestiary normally.
+func set_character_mode(enabled : bool) -> void :
+	if enabled :
+		_enter_expanded()
+		listrect.hide()
+	else :
+		_exit_expanded()
+		listrect.show()
 
-func _on_close_button_pressed():
+
+# In expanded mode we reparent to the HUD root so we draw on top of HBoxBot,
+# rather than hiding TextRect/CreatureRect (which reflows HBoxBot and pushes
+# BotRightPanel under us).
+func _enter_expanded() -> void :
+	if _expanded :
+		return
+	_expanded = true
+	var hud = UI.ow_hud
+	var hud_size : Vector2 = hud.size if hud else Vector2(1152, 648)
+	_original_parent = get_parent()
+	_original_index = get_index()
+	var parent_w : float = _original_parent.size.x if _original_parent else 832.0
+	if hud and _original_parent != hud :
+		_original_parent.remove_child(self)
+		hud.add_child(self)
+	top_level = true
+	set_anchors_and_offsets_preset(Control.PRESET_TOP_LEFT)
+	position = Vector2.ZERO
+	size = Vector2(parent_w, hud_size.y)
+
+
+func _exit_expanded() -> void :
+	if not _expanded :
+		return
+	_expanded = false
+	top_level = false
+	if _original_parent != null and get_parent() != _original_parent :
+		get_parent().remove_child(self)
+		_original_parent.add_child(self)
+		if _original_index >= 0 :
+			_original_parent.move_child(self, _original_index)
+	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_original_parent = null
+	_original_index = -1
+
+
+func _on_entry_pressed(cdata) -> void :
+	var data : Dictionary = cdata.get("data", {})
+	var stats : Dictionary = cdata.get("stats", {})
+	var tools : Dictionary = cdata.get("tools", {})
+
+	name_label.text = str(data.get("name", "Unknown"))
+
+	var lvl : int = int(data.get("level", 1))
+	portrait_lvl_label.text = "Lv %d" % lvl
+
+	var img = data.get("image", null)
+	if img != null :
+		portrait_texrect.texture = img
+
+	# Subtitle: explicit override (e.g. "Gnome Warlock") wins; else fall back to
+	# "Level X · first-tag" for creatures.
+	var tags : Array = data.get("tags", [])
+	var subtitle_override = data.get("subtitle", null)
+	if subtitle_override != null and not str(subtitle_override).is_empty() :
+		subtitle_label.text = "Level %d · %s" % [lvl, str(subtitle_override)]
+	else :
+		var subtitle_parts : Array = ["Level %d" % lvl]
+		if tags.size() > 0 :
+			subtitle_parts.append(str(tags[0]))
+		subtitle_label.text = " · ".join(subtitle_parts)
+
+	# HP / SP
+	var max_hp : int = int(stats.get("maxHP", 0))
+	var max_sp : int = int(stats.get("maxSP", 0))
+	hp_label.text = "HP %d" % max_hp
+	sp_label.text = "SP %d" % max_sp
+
+	_rebuild_stats_grid(stats)
+	_rebuild_resists_grid(stats)
+	_populate_aux_panel(cdata, tags, tools)
+
+	descr_label.text = str(data.get("description", ""))
+
+
+# The bottom-left panel shows TAGS+ABILITIES for creatures, or SPECIAL SKILLS
+# for player characters when cdata["special_skills"] is provided.
+func _populate_aux_panel(cdata, tags : Array, tools : Dictionary) -> void :
+	var special_skills : Array = cdata.get("special_skills", [])
+	if special_skills.size() > 0 :
+		tags_header.text = "SPECIAL SKILLS"
+		tags_label.hide()
+		abil_spacer.hide()
+		abilities_header.hide()
+		abilities_label.hide()
+		_rebuild_special_grid(special_skills)
+		special_grid.show()
+		return
+
+	special_grid.hide()
+	tags_label.show()
+	tags_header.text = "TAGS"
+	if tags.is_empty() :
+		tags_label.text = "—"
+	else :
+		tags_label.text = ", ".join(tags.map(func(t): return str(t)))
+	abil_spacer.show()
+	abilities_header.show()
+	abilities_label.show()
+	var abilities : Array = tools.get("spells", [])
+	if abilities.is_empty() :
+		abilities_label.text = "—"
+	else :
+		var parts : Array = []
+		for s in abilities :
+			parts.append("%s (Lv %s)" % [s[0], s[1]])
+		abilities_label.text = ", ".join(parts)
+
+
+func _rebuild_special_grid(skills : Array) -> void :
+	for c in special_grid.get_children() :
+		c.queue_free()
+	for entry in skills :
+		var name_lbl := Label.new()
+		name_lbl.text = str(entry[0])
+		name_lbl.add_theme_font_size_override("font_size", 13)
+		name_lbl.add_theme_color_override("font_color", COLOR_LABEL)
+		name_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		name_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+		special_grid.add_child(name_lbl)
+
+		var val_str : String = str(entry[1])
+		var val_lbl := Label.new()
+		val_lbl.text = val_str
+		val_lbl.add_theme_font_size_override("font_size", 13)
+		val_lbl.add_theme_color_override("font_color", _color_for_signed_str(val_str))
+		val_lbl.custom_minimum_size = Vector2(72, 0)
+		val_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+		special_grid.add_child(val_lbl)
+
+
+# Color positive/negative formatted strings (e.g. "+12.5%" -> green, "-3" -> red).
+func _color_for_signed_str(s : String) -> Color :
+	if s.begins_with("-") :
+		return COLOR_BAD
+	if s.begins_with("+") :
+		return COLOR_GOOD
+	return COLOR_VALUE
+
+
+func _rebuild_stats_grid(stats : Dictionary) -> void :
+	for c in stats_grid.get_children() :
+		c.queue_free()
+	for row in STAT_ROWS :
+		_add_stat_cell(row[0], false)
+		_add_stat_cell(_format_stat(stats.get(row[1], 0)), true)
+
+
+func _add_stat_cell(text : String, is_value : bool) -> void :
+	var lbl := Label.new()
+	lbl.text = text
+	lbl.add_theme_font_size_override("font_size", 13)
+	lbl.add_theme_color_override("font_shadow_color", COLOR_SHADOW)
+	lbl.add_theme_constant_override("shadow_offset_x", 1)
+	lbl.add_theme_constant_override("shadow_offset_y", 1)
+	if is_value :
+		lbl.add_theme_color_override("font_color", COLOR_VALUE)
+		lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+	else :
+		lbl.add_theme_color_override("font_color", COLOR_LABEL)
+		lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	stats_grid.add_child(lbl)
+
+
+func _rebuild_resists_grid(stats : Dictionary) -> void :
+	for c in resists_grid.get_children() :
+		c.queue_free()
+
+	# Column header row
+	_add_resist_header("TYPE", HORIZONTAL_ALIGNMENT_LEFT)
+	_add_resist_header("RES", HORIZONTAL_ALIGNMENT_RIGHT)
+	_add_resist_header("MULT", HORIZONTAL_ALIGNMENT_RIGHT)
+
+	for row in RESIST_ROWS :
+		var display_name : String = row[0]
+		var key : String = row[1]
+		var res_val = stats.get("Resistance" + key, 0)
+		var mult_val = stats.get("Multiplier" + key, 1.0)
+		_add_resist_label(display_name, COLOR_LABEL, HORIZONTAL_ALIGNMENT_LEFT)
+		_add_resist_value(_format_resist_pct(res_val), _color_for_resist(res_val), HORIZONTAL_ALIGNMENT_RIGHT)
+		_add_resist_value(_format_mult(mult_val), _color_for_mult(mult_val), HORIZONTAL_ALIGNMENT_RIGHT)
+
+
+func _add_resist_header(text : String, align : int) -> void :
+	var lbl := Label.new()
+	lbl.text = text
+	lbl.add_theme_font_size_override("font_size", 11)
+	lbl.add_theme_color_override("font_color", COLOR_DIM)
+	lbl.add_theme_color_override("font_shadow_color", COLOR_SHADOW)
+	lbl.add_theme_constant_override("shadow_offset_x", 1)
+	lbl.add_theme_constant_override("shadow_offset_y", 1)
+	lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	lbl.horizontal_alignment = align
+	resists_grid.add_child(lbl)
+
+
+func _add_resist_label(text : String, color : Color, align : int) -> void :
+	var lbl := Label.new()
+	lbl.text = text
+	lbl.add_theme_font_size_override("font_size", 13)
+	lbl.add_theme_color_override("font_color", color)
+	lbl.add_theme_color_override("font_shadow_color", COLOR_SHADOW)
+	lbl.add_theme_constant_override("shadow_offset_x", 1)
+	lbl.add_theme_constant_override("shadow_offset_y", 1)
+	lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	lbl.horizontal_alignment = align
+	resists_grid.add_child(lbl)
+
+
+func _add_resist_value(text : String, color : Color, align : int) -> void :
+	var lbl := Label.new()
+	lbl.text = text
+	lbl.add_theme_font_size_override("font_size", 13)
+	lbl.add_theme_color_override("font_color", color)
+	lbl.add_theme_color_override("font_shadow_color", COLOR_SHADOW)
+	lbl.add_theme_constant_override("shadow_offset_x", 1)
+	lbl.add_theme_constant_override("shadow_offset_y", 1)
+	lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	lbl.horizontal_alignment = align
+	resists_grid.add_child(lbl)
+
+
+func _format_stat(v) -> String :
+	if v is float :
+		# Drop trailing zeros: 1.00 -> 1, 1.06 -> 1.06.
+		var s : String = "%.2f" % v
+		if "." in s :
+			s = s.rstrip("0").rstrip(".")
+			if s == "" or s == "-" :
+				s = "0"
+		return s
+	return str(v)
+
+
+func _format_resist_pct(v) -> String :
+	var f : float = float(v)
+	if abs(f) < 0.005 :
+		return "0"
+	return "%d%%" % int(round(f * 100.0)) if abs(f) < 1.5 else "%d" % int(round(f))
+
+
+func _format_mult(v) -> String :
+	var f : float = float(v)
+	if abs(f - 1.0) < 0.005 :
+		# Default multiplier (no modifier) — render blank to avoid visual noise.
+		return ""
+	# Show 2 decimals trimmed.
+	var s : String = "%.2f" % f
+	if "." in s :
+		s = s.rstrip("0").rstrip(".")
+	return "×" + s
+
+
+func _color_for_resist(v) -> Color :
+	var f : float = float(v)
+	if f > 0.005 :
+		return COLOR_GOOD
+	if f < -0.005 :
+		return COLOR_BAD
+	return COLOR_DIM
+
+
+func _color_for_mult(v) -> Color :
+	var f : float = float(v)
+	if f < 1.0 - 0.005 :
+		return COLOR_GOOD
+	if f > 1.0 + 0.005 :
+		return COLOR_BAD
+	return COLOR_DIM
+
+
+func _on_close_button_pressed() -> void :
+	set_character_mode(false)
 	hide()
 	StateMachine.transition_to("Exploration/ExWalking")
 
 
-func _on_line_edit_text_changed(new_text: String):
+func _on_line_edit_text_changed(new_text : String) -> void :
 	if new_text.is_empty() :
 		for b in entrycontainer.get_children() :
 			b.show()

--- a/src/scenes/UI/HUD/Bestiary/bestiary_rect.tscn
+++ b/src/scenes/UI/HUD/Bestiary/bestiary_rect.tscn
@@ -1,47 +1,26 @@
-[gd_scene load_steps=7 format=3 uid="uid://cjpb8ppwrbrtl"]
+[gd_scene load_steps=5 format=3 uid="uid://cjpb8ppwrbrtl"]
 
-[ext_resource type="Texture2D" uid="uid://baijqqoeouga7" path="res://shared_assets/UI/StonePatternRect9.png" id="1_3d0g0"]
-[ext_resource type="Script" path="res://scenes/UI/HUD/Bestiary/bestiary_rect.gd" id="2_l1a6x"]
-[ext_resource type="PackedScene" uid="uid://cy33c86e0nsoa" path="res://scenes/UI/HUD/Bestiary/bestiary_button.tscn" id="3_o15vd"]
-[ext_resource type="FontFile" path="res://Fonts/BlackChancery.tres" id="4_ev21x"]
-[ext_resource type="StyleBox" path="res://shared_assets/UI/button_normal_styleboxtexture.tres" id="5_btn_n"]
-[ext_resource type="StyleBox" path="res://shared_assets/UI/button_hover_styleboxtexture.tres" id="6_btn_h"]
-[ext_resource type="StyleBox" path="res://shared_assets/UI/button_pressed_styleboxtexture.tres" id="7_btn_p"]
+[ext_resource type="Texture2D" uid="uid://baijqqoeouga7" path="res://shared_assets/UI/StonePatternRect9.png" id="1_stone"]
+[ext_resource type="Script" path="res://scenes/UI/HUD/Bestiary/bestiary_rect.gd" id="2_script"]
+[ext_resource type="PackedScene" uid="uid://cy33c86e0nsoa" path="res://scenes/UI/HUD/Bestiary/bestiary_button.tscn" id="3_btn"]
+[ext_resource type="FontFile" path="res://Fonts/BlackChancery.tres" id="4_font"]
+[ext_resource type="PackedScene" uid="uid://b2x4kchstat01" path="res://scenes/UI/HUD/Characters Panel/creature_info_panel.tscn" id="5_info"]
 
-[node name="BestiaryRect" type="NinePatchRect" node_paths=PackedStringArray("listrect", "entrycontainer", "search_lineedit", "portrait_texrect", "portrait_lvl_label", "name_label", "subtitle_label", "hp_label", "sp_label", "stats_grid", "resists_grid", "tags_header", "tags_label", "special_grid", "abil_spacer", "abilities_header", "abilities_label", "descr_label", "close_button")]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-texture = ExtResource("1_3d0g0")
+[node name="BestiaryRect" type="NinePatchRect" node_paths=PackedStringArray("entrycontainer", "search_lineedit", "info_panel")]
+offset_right = 832.0
+offset_bottom = 648.0
+texture = ExtResource("1_stone")
 patch_margin_left = 11
 patch_margin_top = 11
 patch_margin_right = 11
 patch_margin_bottom = 11
 axis_stretch_horizontal = 1
 axis_stretch_vertical = 1
-script = ExtResource("2_l1a6x")
-button_tscn = ExtResource("3_o15vd")
-listrect = NodePath("OuterMargin/HBox/ListRect")
+script = ExtResource("2_script")
+button_tscn = ExtResource("3_btn")
 entrycontainer = NodePath("OuterMargin/HBox/ListRect/ListMargin/ListVBox/ListScroll/EntryContainer")
 search_lineedit = NodePath("OuterMargin/HBox/ListRect/ListMargin/ListVBox/SearchLineEdit")
-portrait_texrect = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/PortraitFrame/PortraitTexture")
-portrait_lvl_label = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/PortraitFrame/LvlLabel")
-name_label = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo/NameLabel")
-subtitle_label = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo/SubtitleLabel")
-hp_label = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo/BarsRow/HPLabel")
-sp_label = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo/BarsRow/SPLabel")
-stats_grid = NodePath("OuterMargin/HBox/InfoVBox/BodyRow/StatsPanel/StatsMargin/StatsVBox/StatsGrid")
-resists_grid = NodePath("OuterMargin/HBox/InfoVBox/BodyRow/ResistPanel/ResistMargin/ResistVBox/ResistsGrid")
-tags_header = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/TagsHeader")
-tags_label = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/TagsValue")
-special_grid = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/SpecialGrid")
-abil_spacer = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/AbilSpacer")
-abilities_header = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/AbilitiesHeader")
-abilities_label = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/AbilitiesValue")
-descr_label = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/LorePanel/LoreMargin/LoreVBox/DescrLabel")
-close_button = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/CloseButton")
+info_panel = NodePath("OuterMargin/HBox/InfoPanel")
 
 [node name="OuterMargin" type="MarginContainer" parent="."]
 layout_mode = 1
@@ -50,19 +29,19 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/margin_left = 8
-theme_override_constants/margin_top = 8
-theme_override_constants/margin_right = 8
-theme_override_constants/margin_bottom = 8
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
 
 [node name="HBox" type="HBoxContainer" parent="OuterMargin"]
 layout_mode = 2
 theme_override_constants/separation = 8
 
 [node name="ListRect" type="NinePatchRect" parent="OuterMargin/HBox"]
-custom_minimum_size = Vector2(208, 0)
+custom_minimum_size = Vector2(288, 0)
 layout_mode = 2
-texture = ExtResource("1_3d0g0")
+texture = ExtResource("1_stone")
 patch_margin_left = 11
 patch_margin_top = 11
 patch_margin_right = 11
@@ -77,10 +56,10 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
+theme_override_constants/margin_left = 14
+theme_override_constants/margin_top = 14
+theme_override_constants/margin_right = 14
+theme_override_constants/margin_bottom = 14
 
 [node name="ListVBox" type="VBoxContainer" parent="OuterMargin/HBox/ListRect/ListMargin"]
 layout_mode = 2
@@ -89,8 +68,8 @@ theme_override_constants/separation = 6
 [node name="SearchHeader" type="Label" parent="OuterMargin/HBox/ListRect/ListMargin/ListVBox"]
 layout_mode = 2
 theme_override_colors/font_color = Color(1, 0.96, 0, 1)
-theme_override_fonts/font = ExtResource("4_ev21x")
-theme_override_font_sizes/font_size = 16
+theme_override_fonts/font = ExtResource("4_font")
+theme_override_font_sizes/font_size = 18
 text = "Bestiary"
 
 [node name="SearchLineEdit" type="LineEdit" parent="OuterMargin/HBox/ListRect/ListMargin/ListVBox"]
@@ -102,6 +81,7 @@ placeholder_text = "Search..."
 layout_mode = 2
 size_flags_vertical = 3
 follow_focus = true
+horizontal_scroll_mode = 0
 vertical_scroll_mode = 2
 
 [node name="EntryContainer" type="VBoxContainer" parent="OuterMargin/HBox/ListRect/ListMargin/ListVBox/ListScroll"]
@@ -109,320 +89,11 @@ layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 0
 
-[node name="InfoVBox" type="VBoxContainer" parent="OuterMargin/HBox"]
+[node name="InfoPanel" parent="OuterMargin/HBox" instance=ExtResource("5_info")]
 layout_mode = 2
-size_flags_horizontal = 3
-theme_override_constants/separation = 8
-
-[node name="HeaderRow" type="HBoxContainer" parent="OuterMargin/HBox/InfoVBox"]
-custom_minimum_size = Vector2(0, 72)
-layout_mode = 2
-theme_override_constants/separation = 10
-
-[node name="PortraitFrame" type="NinePatchRect" parent="OuterMargin/HBox/InfoVBox/HeaderRow"]
-custom_minimum_size = Vector2(72, 72)
-layout_mode = 2
-texture = ExtResource("1_3d0g0")
-patch_margin_left = 11
-patch_margin_top = 11
-patch_margin_right = 11
-patch_margin_bottom = 11
-axis_stretch_horizontal = 1
-axis_stretch_vertical = 1
-
-[node name="PortraitTexture" type="TextureRect" parent="OuterMargin/HBox/InfoVBox/HeaderRow/PortraitFrame"]
-layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -28.0
-offset_top = -28.0
-offset_right = 28.0
-offset_bottom = 28.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
-expand_mode = 1
-stretch_mode = 5
-
-[node name="LvlLabel" type="Label" parent="OuterMargin/HBox/InfoVBox/HeaderRow/PortraitFrame"]
-layout_mode = 1
-anchors_preset = 7
-anchor_left = 0.5
-anchor_top = 1.0
-anchor_right = 0.5
-anchor_bottom = 1.0
-offset_left = -28.0
-offset_top = -18.0
-offset_right = 28.0
-offset_bottom = -2.0
-grow_horizontal = 2
-grow_vertical = 0
-theme_override_colors/font_color = Color(1, 0.96, 0, 1)
-theme_override_font_sizes/font_size = 12
-text = "Lv 1"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="HeroInfo" type="VBoxContainer" parent="OuterMargin/HBox/InfoVBox/HeaderRow"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_constants/separation = 4
-
-[node name="NameLabel" type="Label" parent="OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo"]
-layout_mode = 2
-theme_override_colors/font_color = Color(1, 0.96, 0, 1)
-theme_override_fonts/font = ExtResource("4_ev21x")
-theme_override_font_sizes/font_size = 22
-text = "Creature Name"
-clip_text = true
-
-[node name="SubtitleLabel" type="Label" parent="OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.82, 0.82, 0.82, 1)
-theme_override_font_sizes/font_size = 13
-text = "Subtitle"
-clip_text = true
-
-[node name="BarsRow" type="HBoxContainer" parent="OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo"]
-layout_mode = 2
-theme_override_constants/separation = 16
-
-[node name="HPLabel" type="Label" parent="OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo/BarsRow"]
-layout_mode = 2
-theme_override_colors/font_color = Color(1, 0.55, 0.55, 1)
-theme_override_font_sizes/font_size = 14
-text = "HP 100"
-
-[node name="SPLabel" type="Label" parent="OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo/BarsRow"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.55, 0.75, 1, 1)
-theme_override_font_sizes/font_size = 14
-text = "SP 100"
-
-[node name="CloseButton" type="Button" parent="OuterMargin/HBox/InfoVBox/HeaderRow"]
-custom_minimum_size = Vector2(64, 28)
-layout_mode = 2
-size_flags_vertical = 0
-theme_override_colors/font_color = Color(1, 0.2, 0.2, 1)
-theme_override_colors/font_hover_color = Color(1, 0.4, 0.4, 1)
-theme_override_colors/font_pressed_color = Color(0.9, 0.2, 0.2, 1)
-theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 3
-theme_override_fonts/font = ExtResource("4_ev21x")
-theme_override_font_sizes/font_size = 16
-theme_override_styles/normal = ExtResource("5_btn_n")
-theme_override_styles/hover = ExtResource("6_btn_h")
-theme_override_styles/pressed = ExtResource("7_btn_p")
-text = "Close"
-
-[node name="BodyRow" type="HBoxContainer" parent="OuterMargin/HBox/InfoVBox"]
-custom_minimum_size = Vector2(0, 272)
-layout_mode = 2
-theme_override_constants/separation = 8
-
-[node name="StatsPanel" type="NinePatchRect" parent="OuterMargin/HBox/InfoVBox/BodyRow"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 1.1
-texture = ExtResource("1_3d0g0")
-patch_margin_left = 11
-patch_margin_top = 11
-patch_margin_right = 11
-patch_margin_bottom = 11
-axis_stretch_horizontal = 1
-axis_stretch_vertical = 1
-
-[node name="StatsMargin" type="MarginContainer" parent="OuterMargin/HBox/InfoVBox/BodyRow/StatsPanel"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_constants/margin_left = 14
-theme_override_constants/margin_top = 14
-theme_override_constants/margin_right = 14
-theme_override_constants/margin_bottom = 14
-
-[node name="StatsVBox" type="VBoxContainer" parent="OuterMargin/HBox/InfoVBox/BodyRow/StatsPanel/StatsMargin"]
-layout_mode = 2
-theme_override_constants/separation = 4
-
-[node name="StatsHeader" type="Label" parent="OuterMargin/HBox/InfoVBox/BodyRow/StatsPanel/StatsMargin/StatsVBox"]
-layout_mode = 2
-theme_override_colors/font_color = Color(1, 0.96, 0, 1)
-theme_override_fonts/font = ExtResource("4_ev21x")
-theme_override_font_sizes/font_size = 14
-text = "STATS"
-
-[node name="StatsGrid" type="GridContainer" parent="OuterMargin/HBox/InfoVBox/BodyRow/StatsPanel/StatsMargin/StatsVBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-theme_override_constants/h_separation = 12
-theme_override_constants/v_separation = 2
-columns = 4
-
-[node name="ResistPanel" type="NinePatchRect" parent="OuterMargin/HBox/InfoVBox/BodyRow"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 1.0
-texture = ExtResource("1_3d0g0")
-patch_margin_left = 11
-patch_margin_top = 11
-patch_margin_right = 11
-patch_margin_bottom = 11
-axis_stretch_horizontal = 1
-axis_stretch_vertical = 1
-
-[node name="ResistMargin" type="MarginContainer" parent="OuterMargin/HBox/InfoVBox/BodyRow/ResistPanel"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_constants/margin_left = 14
-theme_override_constants/margin_top = 14
-theme_override_constants/margin_right = 14
-theme_override_constants/margin_bottom = 14
-
-[node name="ResistVBox" type="VBoxContainer" parent="OuterMargin/HBox/InfoVBox/BodyRow/ResistPanel/ResistMargin"]
-layout_mode = 2
-theme_override_constants/separation = 4
-
-[node name="ResistHeader" type="Label" parent="OuterMargin/HBox/InfoVBox/BodyRow/ResistPanel/ResistMargin/ResistVBox"]
-layout_mode = 2
-theme_override_colors/font_color = Color(1, 0.96, 0, 1)
-theme_override_fonts/font = ExtResource("4_ev21x")
-theme_override_font_sizes/font_size = 14
-text = "RESISTANCES"
-
-[node name="ResistsGrid" type="GridContainer" parent="OuterMargin/HBox/InfoVBox/BodyRow/ResistPanel/ResistMargin/ResistVBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-theme_override_constants/h_separation = 8
-theme_override_constants/v_separation = 2
-columns = 3
-
-[node name="BottomRow" type="HBoxContainer" parent="OuterMargin/HBox/InfoVBox"]
-custom_minimum_size = Vector2(0, 92)
-layout_mode = 2
-size_flags_vertical = 3
-theme_override_constants/separation = 8
-
-[node name="TagsAbilPanel" type="NinePatchRect" parent="OuterMargin/HBox/InfoVBox/BottomRow"]
-layout_mode = 2
-size_flags_horizontal = 3
-texture = ExtResource("1_3d0g0")
-patch_margin_left = 11
-patch_margin_top = 11
-patch_margin_right = 11
-patch_margin_bottom = 11
-axis_stretch_horizontal = 1
-axis_stretch_vertical = 1
-
-[node name="TAMargin" type="MarginContainer" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_constants/margin_left = 14
-theme_override_constants/margin_top = 14
-theme_override_constants/margin_right = 14
-theme_override_constants/margin_bottom = 14
-
-[node name="TAVBox" type="VBoxContainer" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin"]
-layout_mode = 2
-theme_override_constants/separation = 2
-
-[node name="TagsHeader" type="Label" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
-layout_mode = 2
-theme_override_colors/font_color = Color(1, 0.96, 0, 1)
-theme_override_fonts/font = ExtResource("4_ev21x")
-theme_override_font_sizes/font_size = 14
-text = "TAGS"
-
-[node name="TagsValue" type="Label" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.92, 0.92, 0.92, 1)
-theme_override_font_sizes/font_size = 12
-text = "—"
-autowrap_mode = 3
-
-[node name="SpecialGrid" type="GridContainer" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
-visible = false
-layout_mode = 2
-theme_override_constants/h_separation = 16
-theme_override_constants/v_separation = 2
-columns = 2
-
-[node name="AbilSpacer" type="Control" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
-custom_minimum_size = Vector2(0, 4)
-layout_mode = 2
-
-[node name="AbilitiesHeader" type="Label" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
-layout_mode = 2
-theme_override_colors/font_color = Color(1, 0.96, 0, 1)
-theme_override_fonts/font = ExtResource("4_ev21x")
-theme_override_font_sizes/font_size = 14
-text = "ABILITIES"
-
-[node name="AbilitiesValue" type="Label" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
-layout_mode = 2
-size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.92, 0.92, 0.92, 1)
-theme_override_font_sizes/font_size = 12
-text = "—"
-autowrap_mode = 3
-
-[node name="LorePanel" type="NinePatchRect" parent="OuterMargin/HBox/InfoVBox/BottomRow"]
-layout_mode = 2
-size_flags_horizontal = 3
-texture = ExtResource("1_3d0g0")
-patch_margin_left = 11
-patch_margin_top = 11
-patch_margin_right = 11
-patch_margin_bottom = 11
-axis_stretch_horizontal = 1
-axis_stretch_vertical = 1
-
-[node name="LoreMargin" type="MarginContainer" parent="OuterMargin/HBox/InfoVBox/BottomRow/LorePanel"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_constants/margin_left = 14
-theme_override_constants/margin_top = 14
-theme_override_constants/margin_right = 14
-theme_override_constants/margin_bottom = 14
-
-[node name="LoreVBox" type="VBoxContainer" parent="OuterMargin/HBox/InfoVBox/BottomRow/LorePanel/LoreMargin"]
-layout_mode = 2
-theme_override_constants/separation = 4
-
-[node name="LoreHeader" type="Label" parent="OuterMargin/HBox/InfoVBox/BottomRow/LorePanel/LoreMargin/LoreVBox"]
-layout_mode = 2
-theme_override_colors/font_color = Color(1, 0.96, 0, 1)
-theme_override_fonts/font = ExtResource("4_ev21x")
-theme_override_font_sizes/font_size = 14
-text = "LORE"
-
-[node name="DescrLabel" type="Label" parent="OuterMargin/HBox/InfoVBox/BottomRow/LorePanel/LoreMargin/LoreVBox"]
-layout_mode = 2
-size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.92, 0.92, 0.92, 1)
-theme_override_font_sizes/font_size = 13
-text = "—"
-autowrap_mode = 3
+stats_columns = 2
+skip_zero_stats = true
+hidden_stat_keys = Array[String](["Weight_Limit", "SP_regen_base", "maxHP", "maxSP"])
+show_outer_bg = false
 
 [connection signal="text_changed" from="OuterMargin/HBox/ListRect/ListMargin/ListVBox/SearchLineEdit" to="." method="_on_line_edit_text_changed"]
-[connection signal="pressed" from="OuterMargin/HBox/InfoVBox/HeaderRow/CloseButton" to="." method="_on_close_button_pressed"]

--- a/src/scenes/UI/HUD/Bestiary/bestiary_rect.tscn
+++ b/src/scenes/UI/HUD/Bestiary/bestiary_rect.tscn
@@ -1,12 +1,14 @@
-[gd_scene load_steps=6 format=3 uid="uid://cjpb8ppwrbrtl"]
+[gd_scene load_steps=7 format=3 uid="uid://cjpb8ppwrbrtl"]
 
 [ext_resource type="Texture2D" uid="uid://baijqqoeouga7" path="res://shared_assets/UI/StonePatternRect9.png" id="1_3d0g0"]
 [ext_resource type="Script" path="res://scenes/UI/HUD/Bestiary/bestiary_rect.gd" id="2_l1a6x"]
 [ext_resource type="PackedScene" uid="uid://cy33c86e0nsoa" path="res://scenes/UI/HUD/Bestiary/bestiary_button.tscn" id="3_o15vd"]
 [ext_resource type="FontFile" path="res://Fonts/BlackChancery.tres" id="4_ev21x"]
-[ext_resource type="Texture2D" uid="uid://dc0qnnd658oln" path="res://scenes/UI/HUD/Looting/ItemGlow.png" id="5_tium4"]
+[ext_resource type="StyleBox" path="res://shared_assets/UI/button_normal_styleboxtexture.tres" id="5_btn_n"]
+[ext_resource type="StyleBox" path="res://shared_assets/UI/button_hover_styleboxtexture.tres" id="6_btn_h"]
+[ext_resource type="StyleBox" path="res://shared_assets/UI/button_pressed_styleboxtexture.tres" id="7_btn_p"]
 
-[node name="BestiaryRect" type="NinePatchRect"]
+[node name="BestiaryRect" type="NinePatchRect" node_paths=PackedStringArray("listrect", "entrycontainer", "search_lineedit", "portrait_texrect", "portrait_lvl_label", "name_label", "subtitle_label", "hp_label", "sp_label", "stats_grid", "resists_grid", "tags_header", "tags_label", "special_grid", "abil_spacer", "abilities_header", "abilities_label", "descr_label", "close_button")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -21,103 +23,104 @@ axis_stretch_horizontal = 1
 axis_stretch_vertical = 1
 script = ExtResource("2_l1a6x")
 button_tscn = ExtResource("3_o15vd")
+listrect = NodePath("OuterMargin/HBox/ListRect")
+entrycontainer = NodePath("OuterMargin/HBox/ListRect/ListMargin/ListVBox/ListScroll/EntryContainer")
+search_lineedit = NodePath("OuterMargin/HBox/ListRect/ListMargin/ListVBox/SearchLineEdit")
+portrait_texrect = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/PortraitFrame/PortraitTexture")
+portrait_lvl_label = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/PortraitFrame/LvlLabel")
+name_label = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo/NameLabel")
+subtitle_label = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo/SubtitleLabel")
+hp_label = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo/BarsRow/HPLabel")
+sp_label = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo/BarsRow/SPLabel")
+stats_grid = NodePath("OuterMargin/HBox/InfoVBox/BodyRow/StatsPanel/StatsMargin/StatsVBox/StatsGrid")
+resists_grid = NodePath("OuterMargin/HBox/InfoVBox/BodyRow/ResistPanel/ResistMargin/ResistVBox/ResistsGrid")
+tags_header = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/TagsHeader")
+tags_label = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/TagsValue")
+special_grid = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/SpecialGrid")
+abil_spacer = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/AbilSpacer")
+abilities_header = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/AbilitiesHeader")
+abilities_label = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/AbilitiesValue")
+descr_label = NodePath("OuterMargin/HBox/InfoVBox/BottomRow/LorePanel/LoreMargin/LoreVBox/DescrLabel")
+close_button = NodePath("OuterMargin/HBox/InfoVBox/HeaderRow/CloseButton")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="."]
+[node name="OuterMargin" type="MarginContainer" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/separation = 0
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_right = 8
+theme_override_constants/margin_bottom = 8
 
-[node name="ListRect" type="NinePatchRect" parent="HBoxContainer"]
-custom_minimum_size = Vector2(256, 0)
+[node name="HBox" type="HBoxContainer" parent="OuterMargin"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="ListRect" type="NinePatchRect" parent="OuterMargin/HBox"]
+custom_minimum_size = Vector2(208, 0)
 layout_mode = 2
 texture = ExtResource("1_3d0g0")
 patch_margin_left = 11
 patch_margin_top = 11
 patch_margin_right = 11
 patch_margin_bottom = 11
-axis_stretch_horizontal = 2
-axis_stretch_vertical = 2
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
 
-[node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer/ListRect"]
+[node name="ListMargin" type="MarginContainer" parent="OuterMargin/HBox/ListRect"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/separation = 0
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
 
-[node name="SearchControl" type="Control" parent="HBoxContainer/ListRect/VBoxContainer"]
-custom_minimum_size = Vector2(0, 74)
+[node name="ListVBox" type="VBoxContainer" parent="OuterMargin/HBox/ListRect/ListMargin"]
 layout_mode = 2
+theme_override_constants/separation = 6
 
-[node name="SearchLabel" type="Label" parent="HBoxContainer/ListRect/VBoxContainer/SearchControl"]
-layout_mode = 0
-offset_left = 15.0
-offset_top = 9.0
-offset_right = 121.0
-offset_bottom = 35.0
-text = "Search Entry :"
-
-[node name="LineEdit" type="LineEdit" parent="HBoxContainer/ListRect/VBoxContainer/SearchControl"]
-layout_mode = 0
-offset_left = 13.0
-offset_top = 33.0
-offset_right = 241.0
-offset_bottom = 64.0
-
-[node name="ListControl" type="Control" parent="HBoxContainer/ListRect/VBoxContainer"]
+[node name="SearchHeader" type="Label" parent="OuterMargin/HBox/ListRect/ListMargin/ListVBox"]
 layout_mode = 2
-size_flags_vertical = 3
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("4_ev21x")
+theme_override_font_sizes/font_size = 16
+text = "Bestiary"
 
-[node name="ScrollContainer" type="ScrollContainer" parent="HBoxContainer/ListRect/VBoxContainer/ListControl"]
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.04
-anchor_right = 0.996
-anchor_bottom = 0.984
-offset_left = -1.24
-offset_right = 0.0239868
-offset_bottom = 0.18396
-grow_horizontal = 2
-grow_vertical = 2
+[node name="SearchLineEdit" type="LineEdit" parent="OuterMargin/HBox/ListRect/ListMargin/ListVBox"]
+custom_minimum_size = Vector2(0, 28)
+layout_mode = 2
+placeholder_text = "Search..."
+
+[node name="ListScroll" type="ScrollContainer" parent="OuterMargin/HBox/ListRect/ListMargin/ListVBox"]
+layout_mode = 2
 size_flags_vertical = 3
 follow_focus = true
 vertical_scroll_mode = 2
 
-[node name="EntryContainer" type="VBoxContainer" parent="HBoxContainer/ListRect/VBoxContainer/ListControl/ScrollContainer"]
+[node name="EntryContainer" type="VBoxContainer" parent="OuterMargin/HBox/ListRect/ListMargin/ListVBox/ListScroll"]
 layout_mode = 2
+size_flags_horizontal = 3
 theme_override_constants/separation = 0
 
-[node name="InfoControl" type="Control" parent="HBoxContainer"]
+[node name="InfoVBox" type="VBoxContainer" parent="OuterMargin/HBox"]
 layout_mode = 2
 size_flags_horizontal = 3
+theme_override_constants/separation = 8
 
-[node name="ScrollContainer" type="ScrollContainer" parent="HBoxContainer/InfoControl"]
-layout_mode = 1
-anchors_preset = -1
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 5.0
-offset_top = 10.0
-offset_right = -1.0
-offset_bottom = -8.0
-
-[node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer"]
+[node name="HeaderRow" type="HBoxContainer" parent="OuterMargin/HBox/InfoVBox"]
+custom_minimum_size = Vector2(0, 72)
 layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
+theme_override_constants/separation = 10
 
-[node name="Control" type="Control" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 3
-
-[node name="StatsRect" type="NinePatchRect" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 108)
+[node name="PortraitFrame" type="NinePatchRect" parent="OuterMargin/HBox/InfoVBox/HeaderRow"]
+custom_minimum_size = Vector2(72, 72)
 layout_mode = 2
 texture = ExtResource("1_3d0g0")
 patch_margin_left = 11
@@ -125,541 +128,301 @@ patch_margin_top = 11
 patch_margin_right = 11
 patch_margin_bottom = 11
 axis_stretch_horizontal = 1
-axis_stretch_vertical = 2
+axis_stretch_vertical = 1
 
-[node name="StatsHBox" type="HBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = 9.0
-offset_right = -10.0
-offset_bottom = -7.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="StatsVBox1" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="MovementLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Movement :"
-horizontal_alignment = 2
-
-[node name="APRLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Actions/Round :"
-horizontal_alignment = 2
-
-[node name="DamageLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Damage Bonus :"
-horizontal_alignment = 2
-
-[node name="StatsVBox2" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="MovementnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox2"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "12"
-
-[node name="APRnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox2"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "4"
-
-[node name="DamagenLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox2"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "2"
-
-[node name="StatsVBox3" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="HPLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Max HP :"
-horizontal_alignment = 2
-
-[node name="SPLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Max SP :"
-horizontal_alignment = 2
-
-[node name="HPrLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "HP Regen :"
-horizontal_alignment = 2
-
-[node name="SPrLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "SP Regen :"
-horizontal_alignment = 2
-
-[node name="StatsVBox4" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="HPnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox4"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "100"
-
-[node name="SPnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox4"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "100"
-
-[node name="HPrnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox4"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "1
-"
-
-[node name="SPrnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox4"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "1"
-
-[node name="StatsVBox5" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="AccMeleeLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox5"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Melee Acc :"
-horizontal_alignment = 2
-
-[node name="AccRangeLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox5"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Range Acc :"
-horizontal_alignment = 2
-
-[node name="AccMagicLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox5"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Magic Acc :"
-horizontal_alignment = 2
-
-[node name="StatsVBox6" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="AccMeleenLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox6"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "100"
-
-[node name="AccRangenLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox6"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "100"
-
-[node name="AccMagicnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox6"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "100"
-
-[node name="StatsVBox7" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="EvaMeleeLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox7"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Melee Eva :"
-horizontal_alignment = 2
-
-[node name="EvaRangeLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox7"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Melee Eva :"
-horizontal_alignment = 2
-
-[node name="EvaMagicLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox7"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Melee Eva :"
-horizontal_alignment = 2
-
-[node name="StatsVBox8" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="EvaMeleenLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox8"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "100"
-
-[node name="EvaRangenLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox8"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "100"
-
-[node name="EvaMagicnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/StatsRect/StatsHBox/StatsVBox8"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "100"
-
-[node name="ResistRect" type="NinePatchRect" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 108)
-layout_mode = 2
-texture = ExtResource("1_3d0g0")
-patch_margin_left = 11
-patch_margin_top = 11
-patch_margin_right = 11
-patch_margin_bottom = 11
-axis_stretch_horizontal = 1
-axis_stretch_vertical = 2
-
-[node name="ResistHBox" type="HBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = 9.0
-offset_right = -10.0
-offset_bottom = -7.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="ResistVBoxS1" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="PhysResLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxS1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Physical Res :"
-horizontal_alignment = 2
-
-[node name="MagiResLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxS1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Magical Res :"
-horizontal_alignment = 2
-
-[node name="HealResLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxS1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Healing Res :"
-horizontal_alignment = 2
-
-[node name="MentalResLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxS1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Mental Res :"
-horizontal_alignment = 2
-
-[node name="ResistVBoxN1" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox"]
-layout_mode = 2
-
-[node name="PhysResnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "12"
-horizontal_alignment = 2
-
-[node name="MagiResnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "4"
-horizontal_alignment = 2
-
-[node name="HealResnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "2"
-horizontal_alignment = 2
-
-[node name="MentResnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "2"
-horizontal_alignment = 2
-
-[node name="ResistVBoxM1" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="PhysMultnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "x1"
-
-[node name="MagiMultnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "x1"
-
-[node name="HealMultLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "x1"
-
-[node name="MentMultLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM1"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "x1"
-
-[node name="ResistVBoxS2" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="FireResLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxS2"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Fire Res :"
-horizontal_alignment = 2
-
-[node name="IceResLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxS2"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Ice Res :"
-horizontal_alignment = 2
-
-[node name="ElecResLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxS2"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Elec Res :"
-horizontal_alignment = 2
-
-[node name="ResistVBoxN2" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox"]
-layout_mode = 2
-
-[node name="FireResnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN2"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "25"
-horizontal_alignment = 2
-
-[node name="IceResnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN2"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "25"
-horizontal_alignment = 2
-
-[node name="ElecResnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN2"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "25"
-horizontal_alignment = 2
-
-[node name="ResistVBoxM2" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="FireMultnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM2"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "x1"
-
-[node name="IceMultnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM2"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "x1"
-
-[node name="ElecMultLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM2"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "x1"
-
-[node name="ResistVBoxS3" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="PosnResLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxS3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Poison Res :"
-horizontal_alignment = 2
-
-[node name="DissResLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxS3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Disease Res :"
-horizontal_alignment = 2
-
-[node name="ChemResLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxS3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "Chemical Res :"
-horizontal_alignment = 2
-
-[node name="ResistVBoxN3" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox"]
-layout_mode = 2
-
-[node name="PosnResnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "100"
-horizontal_alignment = 2
-
-[node name="DissResnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "100"
-horizontal_alignment = 2
-
-[node name="ChemResnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxN3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "100"
-horizontal_alignment = 2
-
-[node name="ResistVBoxM3" type="VBoxContainer" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="PoisMultnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "x1"
-
-[node name="DissMultnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "x1"
-
-[node name="ChemMultnLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/ResistRect/ResistHBox/ResistVBoxM3"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 12
-text = "x1"
-
-[node name="AbilitiesRect" type="Control" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 64)
-layout_mode = 2
-
-[node name="TagsLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/AbilitiesRect"]
-layout_mode = 0
-offset_right = 40.0
-offset_bottom = 23.0
-text = "Tags :"
-
-[node name="TagsLabel2" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/AbilitiesRect"]
-layout_mode = 0
-offset_left = 51.0
-offset_right = 95.0
-offset_bottom = 26.0
-text = "Magic User, Undead, Demonic, Reptilian, Evil, Intelligent"
-
-[node name="AbilitiesLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/AbilitiesRect"]
-layout_mode = 0
-offset_left = 1.0
-offset_top = 31.0
-offset_right = 63.0
-offset_bottom = 57.0
-text = "Abilities :"
-
-[node name="AbilitiesLabel2" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/AbilitiesRect"]
-layout_mode = 0
-offset_left = 79.0
-offset_top = 32.0
-offset_right = 866.0
-offset_bottom = 58.0
-text = "Apocalypse Lv7, Ultima Lv7, Tiltowait Lv7, Supernova Lv7, Firaja Lv7"
-
-[node name="LoreRect" type="NinePatchRect" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer"]
-custom_minimum_size = Vector2(0, 128)
-layout_mode = 2
-texture = ExtResource("1_3d0g0")
-patch_margin_left = 11
-patch_margin_top = 11
-patch_margin_right = 11
-patch_margin_bottom = 11
-axis_stretch_horizontal = 1
-axis_stretch_vertical = 2
-
-[node name="NameLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/LoreRect"]
-layout_mode = 0
-offset_left = 90.0
-offset_top = 13.0
-offset_right = 209.0
-offset_bottom = 39.0
-theme_override_fonts/font = ExtResource("4_ev21x")
-theme_override_font_sizes/font_size = 20
-text = "Creature Name"
-
-[node name="DescrLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/LoreRect"]
-layout_mode = 1
-anchors_preset = -1
-anchor_top = 0.305
-anchor_right = 1.0
-anchor_bottom = 0.93
-offset_left = 89.0
-offset_top = -0.0400009
-offset_right = -9.0
-offset_bottom = -0.0400085
-theme_override_font_sizes/font_size = 12
-text = "Aliquam convallis sollicitudin purus. Praesent aliquam, enim at fermentum mollis, ligula massa adipiscing nisl, ac euismod nibh nisl eu lectus. Fusce vulputate sem at sapien. Vivamus leo. Aliquam euismod libero eu enim. Nulla nec felis sed leo placerat imperdiet. Aenean suscipit nulla in justo. Suspendisse cursus rutrum augue. Nulla tincidunt tincidunt mi. Curabitur iaculis, lorem vel rhoncus faucibus, felis magna fermentum augue, et ultricies lacus lorem varius purus. Curabitur eu amet."
-autowrap_mode = 3
-
-[node name="NinePatchRect" type="NinePatchRect" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/LoreRect"]
-custom_minimum_size = Vector2(70, 70)
-layout_mode = 0
-offset_left = 14.0
-offset_top = 14.0
-offset_right = 84.0
-offset_bottom = 84.0
-texture = ExtResource("1_3d0g0")
-
-[node name="TextureRect" type="TextureRect" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/LoreRect/NinePatchRect"]
+[node name="PortraitTexture" type="TextureRect" parent="OuterMargin/HBox/InfoVBox/HeaderRow/PortraitFrame"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -32.0
-offset_top = -32.0
-offset_right = 32.0
-offset_bottom = 32.0
+offset_left = -28.0
+offset_top = -28.0
+offset_right = 28.0
+offset_bottom = 28.0
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
-texture = ExtResource("5_tium4")
+expand_mode = 1
+stretch_mode = 5
 
-[node name="LvlLabel" type="Label" parent="HBoxContainer/InfoControl/ScrollContainer/VBoxContainer/LoreRect/NinePatchRect"]
-layout_mode = 0
-offset_left = -2.0
-offset_top = 71.0
-offset_right = 71.0
-offset_bottom = 103.0
+[node name="LvlLabel" type="Label" parent="OuterMargin/HBox/InfoVBox/HeaderRow/PortraitFrame"]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -28.0
+offset_top = -18.0
+offset_right = 28.0
+offset_bottom = -2.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
 theme_override_font_sizes/font_size = 12
-text = "Level 500"
+text = "Lv 1"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="CloseButton" type="Button" parent="HBoxContainer/InfoControl"]
-layout_mode = 1
-anchors_preset = 3
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -41.0
-offset_top = -37.0
-offset_right = 9.0
-offset_bottom = -6.0
-grow_horizontal = 0
-grow_vertical = 0
-scale = Vector2(0.6, 0.6)
+[node name="HeroInfo" type="VBoxContainer" parent="OuterMargin/HBox/InfoVBox/HeaderRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 4
+
+[node name="NameLabel" type="Label" parent="OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("4_ev21x")
+theme_override_font_sizes/font_size = 22
+text = "Creature Name"
+clip_text = true
+
+[node name="SubtitleLabel" type="Label" parent="OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.82, 0.82, 0.82, 1)
+theme_override_font_sizes/font_size = 13
+text = "Subtitle"
+clip_text = true
+
+[node name="BarsRow" type="HBoxContainer" parent="OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo"]
+layout_mode = 2
+theme_override_constants/separation = 16
+
+[node name="HPLabel" type="Label" parent="OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo/BarsRow"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.55, 0.55, 1)
+theme_override_font_sizes/font_size = 14
+text = "HP 100"
+
+[node name="SPLabel" type="Label" parent="OuterMargin/HBox/InfoVBox/HeaderRow/HeroInfo/BarsRow"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.55, 0.75, 1, 1)
+theme_override_font_sizes/font_size = 14
+text = "SP 100"
+
+[node name="CloseButton" type="Button" parent="OuterMargin/HBox/InfoVBox/HeaderRow"]
+custom_minimum_size = Vector2(64, 28)
+layout_mode = 2
+size_flags_vertical = 0
+theme_override_colors/font_color = Color(1, 0.2, 0.2, 1)
+theme_override_colors/font_hover_color = Color(1, 0.4, 0.4, 1)
+theme_override_colors/font_pressed_color = Color(0.9, 0.2, 0.2, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 3
+theme_override_fonts/font = ExtResource("4_ev21x")
+theme_override_font_sizes/font_size = 16
+theme_override_styles/normal = ExtResource("5_btn_n")
+theme_override_styles/hover = ExtResource("6_btn_h")
+theme_override_styles/pressed = ExtResource("7_btn_p")
 text = "Close"
 
-[connection signal="text_changed" from="HBoxContainer/ListRect/VBoxContainer/SearchControl/LineEdit" to="." method="_on_line_edit_text_changed"]
-[connection signal="pressed" from="HBoxContainer/InfoControl/CloseButton" to="." method="_on_close_button_pressed"]
+[node name="BodyRow" type="HBoxContainer" parent="OuterMargin/HBox/InfoVBox"]
+custom_minimum_size = Vector2(0, 272)
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="StatsPanel" type="NinePatchRect" parent="OuterMargin/HBox/InfoVBox/BodyRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 1.1
+texture = ExtResource("1_3d0g0")
+patch_margin_left = 11
+patch_margin_top = 11
+patch_margin_right = 11
+patch_margin_bottom = 11
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+
+[node name="StatsMargin" type="MarginContainer" parent="OuterMargin/HBox/InfoVBox/BodyRow/StatsPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 14
+theme_override_constants/margin_top = 14
+theme_override_constants/margin_right = 14
+theme_override_constants/margin_bottom = 14
+
+[node name="StatsVBox" type="VBoxContainer" parent="OuterMargin/HBox/InfoVBox/BodyRow/StatsPanel/StatsMargin"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="StatsHeader" type="Label" parent="OuterMargin/HBox/InfoVBox/BodyRow/StatsPanel/StatsMargin/StatsVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("4_ev21x")
+theme_override_font_sizes/font_size = 14
+text = "STATS"
+
+[node name="StatsGrid" type="GridContainer" parent="OuterMargin/HBox/InfoVBox/BodyRow/StatsPanel/StatsMargin/StatsVBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/h_separation = 12
+theme_override_constants/v_separation = 2
+columns = 4
+
+[node name="ResistPanel" type="NinePatchRect" parent="OuterMargin/HBox/InfoVBox/BodyRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 1.0
+texture = ExtResource("1_3d0g0")
+patch_margin_left = 11
+patch_margin_top = 11
+patch_margin_right = 11
+patch_margin_bottom = 11
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+
+[node name="ResistMargin" type="MarginContainer" parent="OuterMargin/HBox/InfoVBox/BodyRow/ResistPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 14
+theme_override_constants/margin_top = 14
+theme_override_constants/margin_right = 14
+theme_override_constants/margin_bottom = 14
+
+[node name="ResistVBox" type="VBoxContainer" parent="OuterMargin/HBox/InfoVBox/BodyRow/ResistPanel/ResistMargin"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="ResistHeader" type="Label" parent="OuterMargin/HBox/InfoVBox/BodyRow/ResistPanel/ResistMargin/ResistVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("4_ev21x")
+theme_override_font_sizes/font_size = 14
+text = "RESISTANCES"
+
+[node name="ResistsGrid" type="GridContainer" parent="OuterMargin/HBox/InfoVBox/BodyRow/ResistPanel/ResistMargin/ResistVBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/h_separation = 8
+theme_override_constants/v_separation = 2
+columns = 3
+
+[node name="BottomRow" type="HBoxContainer" parent="OuterMargin/HBox/InfoVBox"]
+custom_minimum_size = Vector2(0, 92)
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="TagsAbilPanel" type="NinePatchRect" parent="OuterMargin/HBox/InfoVBox/BottomRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+texture = ExtResource("1_3d0g0")
+patch_margin_left = 11
+patch_margin_top = 11
+patch_margin_right = 11
+patch_margin_bottom = 11
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+
+[node name="TAMargin" type="MarginContainer" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 14
+theme_override_constants/margin_top = 14
+theme_override_constants/margin_right = 14
+theme_override_constants/margin_bottom = 14
+
+[node name="TAVBox" type="VBoxContainer" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin"]
+layout_mode = 2
+theme_override_constants/separation = 2
+
+[node name="TagsHeader" type="Label" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("4_ev21x")
+theme_override_font_sizes/font_size = 14
+text = "TAGS"
+
+[node name="TagsValue" type="Label" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.92, 0.92, 0.92, 1)
+theme_override_font_sizes/font_size = 12
+text = "—"
+autowrap_mode = 3
+
+[node name="SpecialGrid" type="GridContainer" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
+visible = false
+layout_mode = 2
+theme_override_constants/h_separation = 16
+theme_override_constants/v_separation = 2
+columns = 2
+
+[node name="AbilSpacer" type="Control" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
+custom_minimum_size = Vector2(0, 4)
+layout_mode = 2
+
+[node name="AbilitiesHeader" type="Label" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("4_ev21x")
+theme_override_font_sizes/font_size = 14
+text = "ABILITIES"
+
+[node name="AbilitiesValue" type="Label" parent="OuterMargin/HBox/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0.92, 0.92, 0.92, 1)
+theme_override_font_sizes/font_size = 12
+text = "—"
+autowrap_mode = 3
+
+[node name="LorePanel" type="NinePatchRect" parent="OuterMargin/HBox/InfoVBox/BottomRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+texture = ExtResource("1_3d0g0")
+patch_margin_left = 11
+patch_margin_top = 11
+patch_margin_right = 11
+patch_margin_bottom = 11
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+
+[node name="LoreMargin" type="MarginContainer" parent="OuterMargin/HBox/InfoVBox/BottomRow/LorePanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 14
+theme_override_constants/margin_top = 14
+theme_override_constants/margin_right = 14
+theme_override_constants/margin_bottom = 14
+
+[node name="LoreVBox" type="VBoxContainer" parent="OuterMargin/HBox/InfoVBox/BottomRow/LorePanel/LoreMargin"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="LoreHeader" type="Label" parent="OuterMargin/HBox/InfoVBox/BottomRow/LorePanel/LoreMargin/LoreVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("4_ev21x")
+theme_override_font_sizes/font_size = 14
+text = "LORE"
+
+[node name="DescrLabel" type="Label" parent="OuterMargin/HBox/InfoVBox/BottomRow/LorePanel/LoreMargin/LoreVBox"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0.92, 0.92, 0.92, 1)
+theme_override_font_sizes/font_size = 13
+text = "—"
+autowrap_mode = 3
+
+[connection signal="text_changed" from="OuterMargin/HBox/ListRect/ListMargin/ListVBox/SearchLineEdit" to="." method="_on_line_edit_text_changed"]
+[connection signal="pressed" from="OuterMargin/HBox/InfoVBox/HeaderRow/CloseButton" to="." method="_on_close_button_pressed"]

--- a/src/scenes/UI/HUD/Characters Panel/CharacterSmallPanel.gd
+++ b/src/scenes/UI/HUD/Characters Panel/CharacterSmallPanel.gd
@@ -243,50 +243,52 @@ func _on_EffectSprite_Timer_timeout():
 
 
 func _on_portrait_button_pressed():
-	UI.ow_hud._on_bestiary_button_pressed()
-	if UI.ow_hud.visible :
-		var cdata : Dictionary = {"data": {}, "stats":{},"tools":{"spells" : []}}
-		cdata["data"]["name"] = character.name
-		var descrString : String = ''
-		match character.is_npc_ally :
-			true :
-				descrString = "One of you allies. "
-			false :
-				match character.is_summoned :
-					true :
-						descrString = "A creature summoned by "+character.summoner_name+". "
-					false :
-						descrString = "One of your characters. A "+ character.racegd.classrace_name+" "+character.classgd.classrace_name+". "
-		
-		var spelcialString :String = ''
-		var specialskillsPercent : Array = ["Melee_Crit_Rate","Melee_Crit_Mult","Ranged_Crit_Rate","Ranged_Crit_Mult"]
-		var specialskillsAbsolute : Array = ["Detect_Secret","Acrobatics","Detect_Trap","Disable_Trap","Force_Lock","Pick_Lock","Turn_Undead"]
-		for s in specialskillsPercent :
-			var stat : float = character.get_stat(s)
-			#print("CharacterSmallPanel specialskillsPercent base_stat: ",s,' ',character.base_stats[s], ", cur stat : ",character.get_stat(s))
-			if stat != 0.0 :
-				spelcialString += s.replace("_"," ") + ' : ' + str(100*stat) + "%, "
-		for s in specialskillsAbsolute :
-			var stat : float = character.get_stat(s)
-			if stat != 0.0 :
-				spelcialString += s.replace("_"," ") + ' : ' + str(stat) + ", "
-		if not spelcialString.is_empty() :
-			descrString += '\n'+spelcialString.trim_suffix(", ")
-		
-		if character.get("selection_pts") :
-			descrString += '\nThis Character has '+ str(character.selection_pts) + ' unused Ability Selection Points.'
-		if character.get("exp_tnl") :
-			descrString += '\nExperience required to level up : '+str(character.exp_tnl)
-		
-		cdata["data"]["description"] = descrString
-		cdata["data"]["level"] = character.level
-		if character.get("icon") :
-			cdata["data"]["image"] = character.icon
-		else :
-			cdata["data"]["image"] = character.textureL
-		cdata["data"]["tags"] = character.tags
-		#printerr("CharacterSmallPanel _on_portrait_button_pressed stats  : \n", str(character.stats))
-		for s in character.stats :
-			printerr("CharacterSmallPanel _on_portrait_button_pressed stats "+s)
-			cdata["stats"][s] = character.get_stat(s)
-		UI.ow_hud.bestiaryRect._on_entry_pressed(cdata)
+	var cdata : Dictionary = {"data": {}, "stats":{},"tools":{"spells" : []}}
+	cdata["data"]["name"] = character.name
+	cdata["data"]["level"] = character.level
+	cdata["data"]["tags"] = character.tags
+	if character.get("icon") :
+		cdata["data"]["image"] = character.icon
+	else :
+		cdata["data"]["image"] = character.textureL
+
+	# Subtitle: "Race · Class" for player chars; allies/summons get a descriptor
+	if character.is_npc_ally :
+		cdata["data"]["subtitle"] = "Ally"
+	elif character.is_summoned :
+		cdata["data"]["subtitle"] = "Summoned by " + character.summoner_name
+	elif character.classgd != null and character.racegd != null :
+		cdata["data"]["subtitle"] = character.racegd.classrace_name + " · " + character.classgd.classrace_name
+
+	# Description: short flavor + progression info. The special-skill stats live
+	# in their own panel via cdata["special_skills"], not here.
+	var descr_parts : Array = []
+	if character.is_npc_ally :
+		descr_parts.append("One of your allies.")
+	elif character.is_summoned :
+		descr_parts.append("A creature summoned by " + character.summoner_name + ".")
+	else :
+		descr_parts.append("One of your characters.")
+	if character.get("selection_pts") and character.selection_pts != 0 :
+		descr_parts.append("%d unused Ability Selection Points." % character.selection_pts)
+	if character.get("exp_tnl") :
+		descr_parts.append("Experience to next level: %d" % character.exp_tnl)
+	cdata["data"]["description"] = "\n".join(descr_parts)
+
+	# Special skills as [name, formatted_value] pairs — only non-zero entries.
+	var special_skills : Array = []
+	var skills_pct : Array = ["Melee_Crit_Rate", "Melee_Crit_Mult", "Ranged_Crit_Rate", "Ranged_Crit_Mult"]
+	var skills_abs : Array = ["Detect_Secret", "Acrobatics", "Detect_Trap", "Disable_Trap", "Force_Lock", "Pick_Lock", "Turn_Undead"]
+	for s in skills_pct :
+		var v : float = character.get_stat(s)
+		if v != 0.0 :
+			special_skills.append([s.replace("_", " "), "%+.1f%%" % (100.0 * v)])
+	for s in skills_abs :
+		var v : float = character.get_stat(s)
+		if v != 0.0 :
+			special_skills.append([s.replace("_", " "), "%+g" % v])
+	cdata["special_skills"] = special_skills
+
+	for s in character.stats :
+		cdata["stats"][s] = character.get_stat(s)
+	UI.ow_hud.bestiaryRect.show_for_character(cdata)

--- a/src/scenes/UI/HUD/Characters Panel/CharacterSmallPanel.gd
+++ b/src/scenes/UI/HUD/Characters Panel/CharacterSmallPanel.gd
@@ -291,4 +291,7 @@ func _on_portrait_button_pressed():
 
 	for s in character.stats :
 		cdata["stats"][s] = character.get_stat(s)
-	UI.ow_hud.bestiaryRect.show_for_character(cdata)
+	# Mutually exclusive with the bestiary — never overlap.
+	if UI.ow_hud.bestiaryRect.visible :
+		UI.ow_hud.bestiaryRect.hide()
+	UI.ow_hud.characterStatRect.show_for_character(cdata)

--- a/src/scenes/UI/HUD/Characters Panel/creature_info_panel.gd
+++ b/src/scenes/UI/HUD/Characters Panel/creature_info_panel.gd
@@ -1,0 +1,338 @@
+extends NinePatchRect
+class_name CreatureInfoPanel
+
+# Shared 4-panel info display (header + stats + resists + tags/abilities/lore).
+# Used standalone as the in-game character stat sheet (instanced directly under
+# OWHUDControl), and embedded inside the bestiary next to the creature list.
+#
+# Public API:
+#   - populate(cdata)            — fill the panel from cdata
+#   - show_for_character(cdata)  — populate + show; for standalone usage
+#   - signal close_requested     — emitted on close button press; the parent
+#                                  decides what to hide and which state to
+#                                  transition to
+signal close_requested
+
+
+func _ready() -> void :
+	# Total inset from the visible outer stone border to the section panels is
+	# 16 in both contexts. Standalone: this panel provides all 16. Embedded:
+	# the parent provides all 16, so this panel adds 0.
+	var outer = get_node_or_null("OuterMargin")
+	var inner_margin : int = 16 if show_outer_bg else 0
+	if outer :
+		outer.add_theme_constant_override("margin_left", inner_margin)
+		outer.add_theme_constant_override("margin_top", inner_margin)
+		outer.add_theme_constant_override("margin_right", inner_margin)
+		outer.add_theme_constant_override("margin_bottom", inner_margin)
+	if not show_outer_bg :
+		# Drop the redundant stone bg — parent already provides one.
+		texture = null
+
+
+# Per-instance customization. Char panel keeps the defaults (4-column stats,
+# show all stats). Bestiary embed overrides to 2 columns + skip-zero + hide
+# stats that don't apply to creatures (Weight Limit, etc.).
+@export var stats_columns : int = 4
+@export var skip_zero_stats : bool = false
+@export var hidden_stat_keys : Array[String] = []
+# When this panel is embedded inside another stone-pattern frame (e.g. the
+# bestiary), the outer stone here would be a redundant third layer.
+@export var show_outer_bg : bool = true
+
+@export var portrait_texrect : TextureRect
+@export var name_label : Label
+@export var subtitle_label : Label
+@export var hp_label : Label
+@export var sp_label : Label
+
+@export var stats_grid : GridContainer
+@export var resists_grid : GridContainer
+
+@export var tags_header : Label
+@export var tags_label : Label
+@export var special_grid : GridContainer
+@export var abil_spacer : Control
+@export var abilities_header : Label
+@export var abilities_label : Label
+@export var descr_label : Label
+@export var close_button : Button
+
+const COLOR_LABEL : Color = Color(0.85, 0.85, 0.85, 1)
+const COLOR_VALUE : Color = Color(1, 1, 1, 1)
+const COLOR_DIM : Color = Color(0.65, 0.65, 0.65, 1)
+const COLOR_GOOD : Color = Color(0.55, 0.85, 0.55, 1)
+const COLOR_BAD : Color = Color(1, 0.5, 0.5, 1)
+
+const STAT_ROWS : Array = [
+	["Movement", "MaxMovement"],
+	["Actions / Round", "MaxActions"],
+	["Weight Limit", "Weight_Limit"],
+	["Strength", "Strength"],
+	["Intellect", "Intellect"],
+	["Wisdom", "Wisdom"],
+	["Dexterity", "Dexterity"],
+	["Vitality", "Vitality"],
+	["Max HP", "maxHP"],
+	["HP Regen", "HP_regen_base"],
+	["Max SP", "maxSP"],
+	["SP Regen", "SP_regen_base"],
+	["Acc · Melee", "AccuracyMelee"],
+	["Eva · Melee", "EvasionMelee"],
+	["Acc · Ranged", "AccuracyRanged"],
+	["Eva · Ranged", "EvasionRanged"],
+	["Acc · Magic", "AccuracyMagic"],
+	["Eva · Magic", "EvasionMagic"],
+]
+
+const RESIST_ROWS : Array = [
+	["Physical", "Physical"],
+	["Magic", "Magic"],
+	["Mental", "Mental"],
+	["Healing", "Healing"],
+	["Fire", "Fire"],
+	["Ice", "Ice"],
+	["Electric", "Elect"],
+	["Poison", "Poison"],
+	["Disease", "Disease"],
+	["Chemical", "Chemical"],
+]
+
+
+func show_for_character(cdata) -> void :
+	populate(cdata)
+	show()
+
+
+func populate(cdata) -> void :
+	var data : Dictionary = cdata.get("data", {})
+	var stats : Dictionary = cdata.get("stats", {})
+	var tools : Dictionary = cdata.get("tools", {})
+
+	name_label.text = str(data.get("name", "Unknown"))
+
+	var lvl : int = int(data.get("level", 1))
+
+	var img = data.get("image", null)
+	if img != null :
+		portrait_texrect.texture = img
+
+	# Subtitle: explicit override (e.g. "Gnome Warlock") wins; else fall back to
+	# "Lv X · first-tag".
+	var tags : Array = data.get("tags", [])
+	var subtitle_override = data.get("subtitle", null)
+	if subtitle_override != null and not str(subtitle_override).is_empty() :
+		subtitle_label.text = "Lv %d · %s" % [lvl, str(subtitle_override)]
+	else :
+		var parts : Array = ["Lv %d" % lvl]
+		if tags.size() > 0 :
+			parts.append(str(tags[0]))
+		subtitle_label.text = " · ".join(parts)
+
+	var max_hp : int = int(stats.get("maxHP", 0))
+	var max_sp : int = int(stats.get("maxSP", 0))
+	hp_label.text = "HP %d" % max_hp
+	sp_label.text = "SP %d" % max_sp
+
+	_rebuild_stats_grid(stats)
+	_rebuild_resists_grid(stats)
+	_populate_aux_panel(cdata, tags, tools)
+
+	descr_label.text = str(data.get("description", ""))
+
+
+# Bottom-left panel: SPECIAL SKILLS for player chars (when cdata provides
+# special_skills); falls back to TAGS+ABILITIES (allies/summons may set tags).
+func _populate_aux_panel(cdata, tags : Array, tools : Dictionary) -> void :
+	var special_skills : Array = cdata.get("special_skills", [])
+	if special_skills.size() > 0 :
+		tags_header.text = "Special Skills"
+		tags_label.hide()
+		abil_spacer.hide()
+		abilities_header.hide()
+		abilities_label.hide()
+		_rebuild_special_grid(special_skills)
+		special_grid.show()
+		return
+
+	special_grid.hide()
+	tags_label.show()
+	tags_header.text = "Tags"
+	if tags.is_empty() :
+		tags_label.text = "—"
+	else :
+		tags_label.text = ", ".join(tags.map(func(t): return str(t)))
+	abil_spacer.show()
+	abilities_header.show()
+	abilities_label.show()
+	var abilities : Array = tools.get("spells", [])
+	if abilities.is_empty() :
+		abilities_label.text = "—"
+	else :
+		var parts : Array = []
+		for s in abilities :
+			parts.append("%s (Lv %s)" % [s[0], s[1]])
+		abilities_label.text = ", ".join(parts)
+
+
+func _rebuild_stats_grid(stats : Dictionary) -> void :
+	stats_grid.columns = stats_columns
+	for c in stats_grid.get_children() :
+		c.queue_free()
+	for row in STAT_ROWS :
+		if row[1] in hidden_stat_keys :
+			continue
+		var v = stats.get(row[1], 0)
+		if skip_zero_stats and _is_zero(v) :
+			continue
+		_add_stat_cell(row[0], false)
+		_add_stat_cell(_format_stat(v), true)
+
+
+func _is_zero(v) -> bool :
+	if v is float :
+		return abs(v) < 0.005
+	return int(v) == 0
+
+
+func _add_stat_cell(text : String, is_value : bool) -> void :
+	var lbl := Label.new()
+	lbl.text = text
+	lbl.add_theme_font_size_override("font_size", 13)
+	if is_value :
+		lbl.add_theme_color_override("font_color", COLOR_VALUE)
+		lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+	else :
+		lbl.add_theme_color_override("font_color", COLOR_LABEL)
+		lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	stats_grid.add_child(lbl)
+
+
+func _rebuild_resists_grid(stats : Dictionary) -> void :
+	for c in resists_grid.get_children() :
+		c.queue_free()
+
+	_add_resist_header("TYPE", HORIZONTAL_ALIGNMENT_LEFT)
+	_add_resist_header("RES", HORIZONTAL_ALIGNMENT_RIGHT)
+	_add_resist_header("MULT", HORIZONTAL_ALIGNMENT_RIGHT)
+
+	for row in RESIST_ROWS :
+		var display_name : String = row[0]
+		var key : String = row[1]
+		var res_val = stats.get("Resistance" + key, 0)
+		var mult_val = stats.get("Multiplier" + key, 1.0)
+		_add_resist_label(display_name, COLOR_LABEL, HORIZONTAL_ALIGNMENT_LEFT)
+		_add_resist_value(_format_resist_pct(res_val), _color_for_resist(res_val), HORIZONTAL_ALIGNMENT_RIGHT)
+		_add_resist_value(_format_mult(mult_val), _color_for_mult(mult_val), HORIZONTAL_ALIGNMENT_RIGHT)
+
+
+func _add_resist_header(text : String, align : int) -> void :
+	var lbl := Label.new()
+	lbl.text = text
+	lbl.add_theme_font_size_override("font_size", 11)
+	lbl.add_theme_color_override("font_color", COLOR_DIM)
+	lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	lbl.horizontal_alignment = align
+	resists_grid.add_child(lbl)
+
+
+func _add_resist_label(text : String, color : Color, align : int) -> void :
+	var lbl := Label.new()
+	lbl.text = text
+	lbl.add_theme_font_size_override("font_size", 13)
+	lbl.add_theme_color_override("font_color", color)
+	lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	lbl.horizontal_alignment = align
+	resists_grid.add_child(lbl)
+
+
+func _add_resist_value(text : String, color : Color, align : int) -> void :
+	var lbl := Label.new()
+	lbl.text = text
+	lbl.add_theme_font_size_override("font_size", 13)
+	lbl.add_theme_color_override("font_color", color)
+	lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	lbl.horizontal_alignment = align
+	resists_grid.add_child(lbl)
+
+
+func _rebuild_special_grid(skills : Array) -> void :
+	for c in special_grid.get_children() :
+		c.queue_free()
+	for entry in skills :
+		var name_lbl := Label.new()
+		name_lbl.text = str(entry[0])
+		name_lbl.add_theme_font_size_override("font_size", 13)
+		name_lbl.add_theme_color_override("font_color", COLOR_LABEL)
+		name_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		name_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+		special_grid.add_child(name_lbl)
+
+		var val_str : String = str(entry[1])
+		var val_lbl := Label.new()
+		val_lbl.text = val_str
+		val_lbl.add_theme_font_size_override("font_size", 13)
+		val_lbl.add_theme_color_override("font_color", _color_for_signed_str(val_str))
+		val_lbl.custom_minimum_size = Vector2(72, 0)
+		val_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+		special_grid.add_child(val_lbl)
+
+
+func _color_for_signed_str(s : String) -> Color :
+	if s.begins_with("-") :
+		return COLOR_BAD
+	if s.begins_with("+") :
+		return COLOR_GOOD
+	return COLOR_VALUE
+
+
+func _format_stat(v) -> String :
+	if v is float :
+		var s : String = "%.2f" % v
+		if "." in s :
+			s = s.rstrip("0").rstrip(".")
+			if s == "" or s == "-" :
+				s = "0"
+		return s
+	return str(v)
+
+
+func _format_resist_pct(v) -> String :
+	var f : float = float(v)
+	if abs(f) < 0.005 :
+		return "0"
+	return "%d%%" % int(round(f * 100.0)) if abs(f) < 1.5 else "%d" % int(round(f))
+
+
+func _format_mult(v) -> String :
+	var f : float = float(v)
+	if abs(f - 1.0) < 0.005 :
+		return ""
+	var s : String = "%.2f" % f
+	if "." in s :
+		s = s.rstrip("0").rstrip(".")
+	return "×" + s
+
+
+func _color_for_resist(v) -> Color :
+	var f : float = float(v)
+	if f > 0.005 :
+		return COLOR_GOOD
+	if f < -0.005 :
+		return COLOR_BAD
+	return COLOR_DIM
+
+
+func _color_for_mult(v) -> Color :
+	var f : float = float(v)
+	if f < 1.0 - 0.005 :
+		return COLOR_GOOD
+	if f > 1.0 + 0.005 :
+		return COLOR_BAD
+	return COLOR_DIM
+
+
+func _on_close_button_pressed() -> void :
+	emit_signal("close_requested")

--- a/src/scenes/UI/HUD/Characters Panel/creature_info_panel.gd.uid
+++ b/src/scenes/UI/HUD/Characters Panel/creature_info_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://cl1xiuyf5cvtf

--- a/src/scenes/UI/HUD/Characters Panel/creature_info_panel.tscn
+++ b/src/scenes/UI/HUD/Characters Panel/creature_info_panel.tscn
@@ -1,0 +1,341 @@
+[gd_scene format=3 uid="uid://b2x4kchstat01"]
+
+[ext_resource type="Texture2D" uid="uid://baijqqoeouga7" path="res://shared_assets/UI/StonePatternRect9.png" id="1_stone"]
+[ext_resource type="Script" path="res://scenes/UI/HUD/Characters Panel/creature_info_panel.gd" id="2_script"]
+[ext_resource type="FontFile" path="res://Fonts/BlackChancery.tres" id="3_font"]
+[ext_resource type="StyleBox" path="res://shared_assets/UI/button_normal_styleboxtexture.tres" id="4_btn_n"]
+[ext_resource type="StyleBox" path="res://shared_assets/UI/button_hover_styleboxtexture.tres" id="5_btn_h"]
+[ext_resource type="StyleBox" path="res://shared_assets/UI/button_pressed_styleboxtexture.tres" id="6_btn_p"]
+
+[node name="CreatureInfoPanel" type="NinePatchRect" node_paths=PackedStringArray("portrait_texrect", "name_label", "subtitle_label", "hp_label", "sp_label", "stats_grid", "resists_grid", "tags_header", "tags_label", "special_grid", "abil_spacer", "abilities_header", "abilities_label", "descr_label", "close_button")]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+texture = ExtResource("1_stone")
+patch_margin_left = 11
+patch_margin_top = 11
+patch_margin_right = 11
+patch_margin_bottom = 11
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+script = ExtResource("2_script")
+portrait_texrect = NodePath("OuterMargin/InfoVBox/HeaderRow/PortraitFrame/PortraitTexture")
+name_label = NodePath("OuterMargin/InfoVBox/HeaderRow/HeroInfo/NameLabel")
+subtitle_label = NodePath("OuterMargin/InfoVBox/HeaderRow/HeroInfo/SubtitleLabel")
+hp_label = NodePath("OuterMargin/InfoVBox/HeaderRow/HeroInfo/BarsRow/HPLabel")
+sp_label = NodePath("OuterMargin/InfoVBox/HeaderRow/HeroInfo/BarsRow/SPLabel")
+stats_grid = NodePath("OuterMargin/InfoVBox/BodyRow/StatsPanel/StatsMargin/StatsVBox/StatsGrid")
+resists_grid = NodePath("OuterMargin/InfoVBox/BodyRow/ResistPanel/ResistMargin/ResistVBox/ResistsGrid")
+tags_header = NodePath("OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/TagsHeader")
+tags_label = NodePath("OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/TagsValue")
+special_grid = NodePath("OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/SpecialGrid")
+abil_spacer = NodePath("OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/AbilSpacer")
+abilities_header = NodePath("OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/AbilitiesHeader")
+abilities_label = NodePath("OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox/AbilitiesValue")
+descr_label = NodePath("OuterMargin/InfoVBox/BottomRow/LorePanel/LoreMargin/LoreVBox/DescrLabel")
+close_button = NodePath("OuterMargin/InfoVBox/HeaderRow/CloseButton")
+
+[node name="OuterMargin" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_right = 8
+theme_override_constants/margin_bottom = 8
+
+[node name="InfoVBox" type="VBoxContainer" parent="OuterMargin"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="HeaderRow" type="HBoxContainer" parent="OuterMargin/InfoVBox"]
+custom_minimum_size = Vector2(0, 72)
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="PortraitFrame" type="NinePatchRect" parent="OuterMargin/InfoVBox/HeaderRow"]
+custom_minimum_size = Vector2(72, 72)
+layout_mode = 2
+texture = ExtResource("1_stone")
+patch_margin_left = 11
+patch_margin_top = 11
+patch_margin_right = 11
+patch_margin_bottom = 11
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+
+[node name="PortraitTexture" type="TextureRect" parent="OuterMargin/InfoVBox/HeaderRow/PortraitFrame"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -28.0
+offset_top = -28.0
+offset_right = 28.0
+offset_bottom = 28.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+expand_mode = 1
+stretch_mode = 5
+
+[node name="HeroInfo" type="VBoxContainer" parent="OuterMargin/InfoVBox/HeaderRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 4
+
+[node name="NameLabel" type="Label" parent="OuterMargin/InfoVBox/HeaderRow/HeroInfo"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("3_font")
+theme_override_font_sizes/font_size = 22
+text = "Character Name"
+clip_text = true
+
+[node name="SubtitleLabel" type="Label" parent="OuterMargin/InfoVBox/HeaderRow/HeroInfo"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("3_font")
+theme_override_font_sizes/font_size = 14
+text = "Subtitle"
+clip_text = true
+
+[node name="BarsRow" type="HBoxContainer" parent="OuterMargin/InfoVBox/HeaderRow/HeroInfo"]
+layout_mode = 2
+theme_override_constants/separation = 16
+
+[node name="HPLabel" type="Label" parent="OuterMargin/InfoVBox/HeaderRow/HeroInfo/BarsRow"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.55, 0.55, 1)
+theme_override_font_sizes/font_size = 14
+text = "HP 100"
+
+[node name="SPLabel" type="Label" parent="OuterMargin/InfoVBox/HeaderRow/HeroInfo/BarsRow"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.55, 0.75, 1, 1)
+theme_override_font_sizes/font_size = 14
+text = "SP 100"
+
+[node name="CloseButton" type="Button" parent="OuterMargin/InfoVBox/HeaderRow"]
+custom_minimum_size = Vector2(64, 28)
+layout_mode = 2
+size_flags_vertical = 0
+theme_override_colors/font_color = Color(1, 0.2, 0.2, 1)
+theme_override_colors/font_hover_color = Color(1, 0.4, 0.4, 1)
+theme_override_colors/font_pressed_color = Color(0.9, 0.2, 0.2, 1)
+theme_override_fonts/font = ExtResource("3_font")
+theme_override_font_sizes/font_size = 16
+theme_override_styles/normal = ExtResource("4_btn_n")
+theme_override_styles/hover = ExtResource("5_btn_h")
+theme_override_styles/pressed = ExtResource("6_btn_p")
+text = "Close"
+
+[node name="BodyRow" type="HBoxContainer" parent="OuterMargin/InfoVBox"]
+custom_minimum_size = Vector2(0, 240)
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="StatsPanel" type="NinePatchRect" parent="OuterMargin/InfoVBox/BodyRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+texture = ExtResource("1_stone")
+patch_margin_left = 11
+patch_margin_top = 11
+patch_margin_right = 11
+patch_margin_bottom = 11
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+
+[node name="StatsMargin" type="MarginContainer" parent="OuterMargin/InfoVBox/BodyRow/StatsPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 14
+theme_override_constants/margin_top = 14
+theme_override_constants/margin_right = 14
+theme_override_constants/margin_bottom = 14
+
+[node name="StatsVBox" type="VBoxContainer" parent="OuterMargin/InfoVBox/BodyRow/StatsPanel/StatsMargin"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="StatsHeader" type="Label" parent="OuterMargin/InfoVBox/BodyRow/StatsPanel/StatsMargin/StatsVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("3_font")
+theme_override_font_sizes/font_size = 18
+text = "Stats"
+
+[node name="StatsGrid" type="GridContainer" parent="OuterMargin/InfoVBox/BodyRow/StatsPanel/StatsMargin/StatsVBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/h_separation = 12
+theme_override_constants/v_separation = 2
+columns = 4
+
+[node name="ResistPanel" type="NinePatchRect" parent="OuterMargin/InfoVBox/BodyRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+texture = ExtResource("1_stone")
+patch_margin_left = 11
+patch_margin_top = 11
+patch_margin_right = 11
+patch_margin_bottom = 11
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+
+[node name="ResistMargin" type="MarginContainer" parent="OuterMargin/InfoVBox/BodyRow/ResistPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 14
+theme_override_constants/margin_top = 14
+theme_override_constants/margin_right = 14
+theme_override_constants/margin_bottom = 14
+
+[node name="ResistVBox" type="VBoxContainer" parent="OuterMargin/InfoVBox/BodyRow/ResistPanel/ResistMargin"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="ResistHeader" type="Label" parent="OuterMargin/InfoVBox/BodyRow/ResistPanel/ResistMargin/ResistVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("3_font")
+theme_override_font_sizes/font_size = 18
+text = "Resistances"
+
+[node name="ResistsGrid" type="GridContainer" parent="OuterMargin/InfoVBox/BodyRow/ResistPanel/ResistMargin/ResistVBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/h_separation = 8
+theme_override_constants/v_separation = 2
+columns = 3
+
+[node name="BottomRow" type="HBoxContainer" parent="OuterMargin/InfoVBox"]
+custom_minimum_size = Vector2(0, 240)
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="TagsAbilPanel" type="NinePatchRect" parent="OuterMargin/InfoVBox/BottomRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+texture = ExtResource("1_stone")
+patch_margin_left = 11
+patch_margin_top = 11
+patch_margin_right = 11
+patch_margin_bottom = 11
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+
+[node name="TAMargin" type="MarginContainer" parent="OuterMargin/InfoVBox/BottomRow/TagsAbilPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 14
+theme_override_constants/margin_top = 14
+theme_override_constants/margin_right = 14
+theme_override_constants/margin_bottom = 14
+
+[node name="TAVBox" type="VBoxContainer" parent="OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin"]
+layout_mode = 2
+theme_override_constants/separation = 2
+
+[node name="TagsHeader" type="Label" parent="OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("3_font")
+theme_override_font_sizes/font_size = 18
+text = "Tags"
+
+[node name="TagsValue" type="Label" parent="OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.92, 0.92, 0.92, 1)
+theme_override_font_sizes/font_size = 13
+text = "—"
+autowrap_mode = 3
+
+[node name="SpecialGrid" type="GridContainer" parent="OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
+visible = false
+layout_mode = 2
+theme_override_constants/h_separation = 16
+theme_override_constants/v_separation = 2
+columns = 2
+
+[node name="AbilSpacer" type="Control" parent="OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
+custom_minimum_size = Vector2(0, 4)
+layout_mode = 2
+
+[node name="AbilitiesHeader" type="Label" parent="OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("3_font")
+theme_override_font_sizes/font_size = 18
+text = "Abilities"
+
+[node name="AbilitiesValue" type="Label" parent="OuterMargin/InfoVBox/BottomRow/TagsAbilPanel/TAMargin/TAVBox"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0.92, 0.92, 0.92, 1)
+theme_override_font_sizes/font_size = 13
+text = "—"
+autowrap_mode = 3
+
+[node name="LorePanel" type="NinePatchRect" parent="OuterMargin/InfoVBox/BottomRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+texture = ExtResource("1_stone")
+patch_margin_left = 11
+patch_margin_top = 11
+patch_margin_right = 11
+patch_margin_bottom = 11
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+
+[node name="LoreMargin" type="MarginContainer" parent="OuterMargin/InfoVBox/BottomRow/LorePanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 14
+theme_override_constants/margin_top = 14
+theme_override_constants/margin_right = 14
+theme_override_constants/margin_bottom = 14
+
+[node name="LoreVBox" type="VBoxContainer" parent="OuterMargin/InfoVBox/BottomRow/LorePanel/LoreMargin"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="LoreHeader" type="Label" parent="OuterMargin/InfoVBox/BottomRow/LorePanel/LoreMargin/LoreVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.96, 0, 1)
+theme_override_fonts/font = ExtResource("3_font")
+theme_override_font_sizes/font_size = 18
+text = "Lore"
+
+[node name="DescrLabel" type="Label" parent="OuterMargin/InfoVBox/BottomRow/LorePanel/LoreMargin/LoreVBox"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0.92, 0.92, 0.92, 1)
+theme_override_font_sizes/font_size = 13
+text = "—"
+autowrap_mode = 3
+
+[connection signal="pressed" from="OuterMargin/InfoVBox/HeaderRow/CloseButton" to="." method="_on_close_button_pressed"]

--- a/src/scenes/UI/HUD/OWHUDControl.gd
+++ b/src/scenes/UI/HUD/OWHUDControl.gd
@@ -555,14 +555,12 @@ func show_spell_effect_on_char_menu(chara, graphic_name : String) :
 
 
 func _on_bestiary_button_pressed():
-	#if not bestiaryRect.visible:
-		#return
 	if bestiaryRect.visible :
+		bestiaryRect.set_character_mode(false)
 		bestiaryRect.hide()
-		#GameState.set_paused(false)
 	else :
+		bestiaryRect.set_character_mode(false)
 		bestiaryRect.show()
-		#GameState.set_paused(true)
 
 func enter_battle_mode() :
 	textRect.hide()

--- a/src/scenes/UI/HUD/OWHUDControl.gd
+++ b/src/scenes/UI/HUD/OWHUDControl.gd
@@ -21,7 +21,8 @@ var selected_character = null
 
 @onready var mapAreaControl : Control = $VBoxScreen/HBoxTop/MapArea
 @onready var inventoryRect = $VBoxScreen/HBoxTop/MapArea/InventoryRect#$InventoryRect
-@onready var bestiaryRect = $VBoxScreen/HBoxTop/MapArea/BestiaryRect
+@onready var bestiaryRect = $BestiaryRect
+@onready var characterStatRect = $CharacterStatRect
 @onready var minimapRect = $VBoxScreen/HBoxTop/MapArea/MinimapsRect
 @onready var pictureRect = $VBoxScreen/HBoxTop/MapArea/PictureRect
 
@@ -96,6 +97,7 @@ func initialize() : # takes an array of Characters GD class objects !
 	set_party_swap_enabled(false)
 	settingsControl._initialize()
 	bestiaryRect._initialize()
+	characterStatRect.close_requested.connect(_on_character_stat_close_requested)
 	if GameGlobal.allow_character_swap_anywhere :
 		set_party_swap_enabled(true)
 #	spellcastMenu.connect("spell_picked", self,"_on_spell_picked"
@@ -556,11 +558,16 @@ func show_spell_effect_on_char_menu(chara, graphic_name : String) :
 
 func _on_bestiary_button_pressed():
 	if bestiaryRect.visible :
-		bestiaryRect.set_character_mode(false)
 		bestiaryRect.hide()
 	else :
-		bestiaryRect.set_character_mode(false)
+		if characterStatRect.visible :
+			characterStatRect.hide()
 		bestiaryRect.show()
+
+
+func _on_character_stat_close_requested() -> void :
+	characterStatRect.hide()
+	StateMachine.transition_to("Exploration/ExWalking")
 
 func enter_battle_mode() :
 	textRect.hide()

--- a/src/scenes/UI/HUD/OWHUDControl.tscn
+++ b/src/scenes/UI/HUD/OWHUDControl.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=78 format=3 uid="uid://bcm4yk3e2uv7"]
+[gd_scene load_steps=79 format=3 uid="uid://bcm4yk3e2uv7"]
 
 [ext_resource type="PackedScene" uid="uid://y2mh6jttjyop" path="res://scenes/UI/HUD/Multiple Choices/ChoicesButton.tscn" id="1"]
 [ext_resource type="Texture2D" uid="uid://baijqqoeouga7" path="res://shared_assets/UI/StonePatternRect9.png" id="2"]
 [ext_resource type="PackedScene" uid="uid://cjpb8ppwrbrtl" path="res://scenes/UI/HUD/Bestiary/bestiary_rect.tscn" id="3_j1454"]
+[ext_resource type="PackedScene" uid="uid://b2x4kchstat01" path="res://scenes/UI/HUD/Characters Panel/creature_info_panel.tscn" id="3_chstat"]
 [ext_resource type="Texture2D" uid="uid://dgpbgtruh0kw8" path="res://scenes/UI/HUD/Button_Items.png" id="5"]
 [ext_resource type="Texture2D" uid="uid://lfonk613cgwb" path="res://shared_assets/UI/stone_pattern.png" id="6"]
 [ext_resource type="PackedScene" uid="uid://biqyyjm2makqt" path="res://scenes/UI/HUD/AbilitiesManagement/abilities_mngt_rect.tscn" id="9_240h7"]
@@ -167,10 +168,6 @@ offset_right = 0.0
 offset_bottom = 0.0
 grow_horizontal = 2
 grow_vertical = 2
-
-[node name="BestiaryRect" parent="VBoxScreen/HBoxTop/MapArea" instance=ExtResource("3_j1454")]
-visible = false
-layout_mode = 1
 
 [node name="AbilitiesMngtRect" parent="VBoxScreen/HBoxTop/MapArea" instance=ExtResource("9_240h7")]
 visible = false
@@ -779,6 +776,18 @@ grow_vertical = 2
 [node name="SaveLoadRect" parent="." instance=ExtResource("10_fxj6e")]
 visible = false
 layout_mode = 1
+
+[node name="BestiaryRect" parent="." instance=ExtResource("3_j1454")]
+visible = false
+layout_mode = 1
+
+[node name="CharacterStatRect" parent="." instance=ExtResource("3_chstat")]
+visible = false
+layout_mode = 1
+offset_right = 832.0
+offset_bottom = 648.0
+size_flags_horizontal = 0
+size_flags_vertical = 0
 
 [node name="Canvaslayer" type="CanvasLayer" parent="."]
 

--- a/src/scripts/game_state.gd
+++ b/src/scripts/game_state.gd
@@ -189,6 +189,12 @@ func send_dir_input(input : Vector2, is_keyboard : bool) :
 		state._on_dir_input_received(input,is_keyboard )
 
 func set_arrow_mouse_cursor(_delta : float) :
+	# When a full-screen overlay panel (bestiary/char-stats, inventory, etc.) is
+	# up, the directional arrow cursor isn't meaningful — we're not navigating
+	# the map. Use the default sword cursor over the panel instead.
+	if _is_overlay_panel_visible() :
+		Input.set_custom_mouse_cursor(UI.cursor_sword)
+		return
 	var mousepos : Vector2 = UI.ow_hud.get_local_mouse_position()
 	var wsize : Vector2 = ScreenUtils.get_logical_window_size(self)
 	if mousepos.x+320<wsize.x and mousepos.y+200<wsize.y :
@@ -198,6 +204,16 @@ func set_arrow_mouse_cursor(_delta : float) :
 		Input.set_custom_mouse_cursor(UI.cursor_map_dict[cursordir])
 	else :
 		Input.set_custom_mouse_cursor((UI.cursor_sword))
+
+
+func _is_overlay_panel_visible() -> bool :
+	var hud = UI.ow_hud
+	if hud == null :
+		return false
+	for n in [hud.bestiaryRect, hud.inventoryRect, hud.minimapRect, hud.abilitesmngtMenu] :
+		if n != null and n.visible :
+			return true
+	return false
 
 #
 #func on_trying_to_move_to_tile_stack(crea : Creature, stack : Array, position : Vector2) : #exporation mode

--- a/src/scripts/game_state.gd
+++ b/src/scripts/game_state.gd
@@ -210,7 +210,7 @@ func _is_overlay_panel_visible() -> bool :
 	var hud = UI.ow_hud
 	if hud == null :
 		return false
-	for n in [hud.bestiaryRect, hud.inventoryRect, hud.minimapRect, hud.abilitesmngtMenu] :
+	for n in [hud.bestiaryRect, hud.characterStatRect, hud.inventoryRect, hud.minimapRect, hud.abilitesmngtMenu] :
 		if n != null and n.visible :
 			return true
 	return false


### PR DESCRIPTION
## Summary

Replaces the cramped 12pt stats wall in the bestiary and the in-game character stat sheet (which previously reused the bestiary scene awkwardly) with a single shared `CreatureInfoPanel` component — a 4-section layout (header / stats grid / resistances grid / tags+abilities or special skills + lore) used standalone for the character sheet and embedded next to the creature list for the bestiary.

Before:
<img width="1151" height="648" alt="image" src="https://github.com/user-attachments/assets/f7d48ca7-e881-48d2-8b44-ec0abd412268" />

<img width="1148" height="650" alt="image" src="https://github.com/user-attachments/assets/f2fd50f5-6a5a-4ed1-b795-7738d868e594" />


After:
<img width="1150" height="652" alt="image" src="https://github.com/user-attachments/assets/8d231d7b-6698-43aa-98e4-de717194e7e2" />

<img width="1150" height="650" alt="image" src="https://github.com/user-attachments/assets/caeeb7c2-4ce5-42bd-b5fc-06e960bb67fd" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)