### PR TITLE
Fix crypt trap-door round trip on map_0/map_5

### DIFF
--- a/src/Campaigns/City of Bywater/Maps/map_0/map_scripts.gd
+++ b/src/Campaigns/City of Bywater/Maps/map_0/map_scripts.gd
@@ -157,8 +157,8 @@ static func AP24x22y14() : #24 at 22,14
 	return
 
 static func AP25x16y17() : #25 at 16,17
-	# This AP teleports to level 5 at 21,5
-	ScriptHelperFuncsClass.teleport_to_map_and_pos_divinity(5, 21, 5, 0)
+	# This AP teleports to level 5 at 21,4 (the staircase tile)
+	ScriptHelperFuncsClass.teleport_to_map_and_pos_divinity(5, 21, 4, 0)
 	await ScriptHelperFuncsClass.display_text_wait_noise('The doors on this crypt are broken as are most in the graveyard.  As you peer in, you happen to see a small crack in the floor.  Your investigation reveals that it is a trap door that leads to a subterranean crypt.', 'message nod.wav')
 	return
 

--- a/src/Campaigns/City of Bywater/Maps/map_5/map_scriptareas.json
+++ b/src/Campaigns/City of Bywater/Maps/map_5/map_scriptareas.json
@@ -34,6 +34,11 @@
       "scriptRectangle" : [ [2,2] , [2,2] ],
       "scriptToLoad" : "Take_Stairs_D"
    },
+   "Stairs Up" :
+   {
+      "scriptRectangle" : [ [21,4] , [21,4] ],
+      "scriptToLoad" : "Take_Stairs_U"
+   },
    "Start Battle" :
    {
       "scriptRectangle" : [ [6,6] , [6,6] ],

--- a/src/Campaigns/City of Bywater/Maps/map_5/map_scripts.gd
+++ b/src/Campaigns/City of Bywater/Maps/map_5/map_scripts.gd
@@ -1,2 +1,8 @@
 static func _on_map_load(_map) :  #Necessary even if unused, replace body with "pass" if so.
 	pass
+
+static func Take_Stairs_U() :
+	# Return to the trap door access point on map_0 (AP25 at 16,17).
+	ScriptHelperFuncsClass.teleport_to_map_and_pos_divinity(0, 16, 17, 0)
+	await ScriptHelperFuncsClass.display_text_wait_noise('You climb back up through the trap door and emerge once more into the abandoned crypt at the edge of the graveyard.', 'message nod.wav')
+	return


### PR DESCRIPTION
This is just a small PR to see how map triggers and scene changes work.

## Summary

Walking south onto **map_0 (16,17)** fired `AP25x16y17`, teleporting the party to map_5 (the subterranean crypt). Two problems:

1. The teleport landed the party at (21,5), one tile *south* of the visible staircase tile (which is at 21,4).
2. map_5 had no `Take_Stairs_U` (or any return-up AP) wired, so once you fell in, you were stuck.

This PR fixes both:

- **`map_0/map_scripts.gd`** — `AP25x16y17` teleport target moved from (21,5) → (21,4) so the party lands directly on the staircase.
- **`map_5/map_scriptareas.json`** — adds a `Stairs Up` rect at (21,4) → `Take_Stairs_U`.
- **`map_5/map_scripts.gd`** — adds the `Take_Stairs_U` body, teleporting back to map_0 (16,17) (the AP25 access tile itself).

Both endpoints are AP tiles. Since `change_map`'s `set_tile_position` doesn't fire APs, neither end loops on arrival — the player has to step off and back on for the AP to retrigger.

> Note: map_5's `map_scriptareas.json` references several other `scriptToLoad` names (`Vodada`, `GlyphScript_One/Two`, `Allow_Char_Swap`, `Find_Treasure`, `Take_Stairs_D`, `Test_Battle`, `example_script`, `Secret_AP`) that have no body in `map_scripts.gd`. Those are out of scope for this PR but stepping on those tiles will still error at runtime.

## Test plan

- [ ] Start a new game / load into Bywater on map_0.
- [ ] Walk south onto tile (16,17). Verify the trap-door text fires and the party lands on the visible staircase tile in map_5 (HUD should read X:21 Y:4).
- [ ] Step off (21,4) (any direction) and back onto it. Verify the climb-back text fires and the party returns to map_0 on the trap-door tile (X:16 Y:17).
- [ ] Step off (16,17) and back south onto it. Verify the trap door retriggers cleanly (round trip works repeatedly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)