### PR TITLE
Add Realmz Dump Importer editor plugin

### DIFF
--- a/src/addons/realmz_dump_importer/README.md
+++ b/src/addons/realmz_dump_importer/README.md
@@ -2,9 +2,9 @@
 
 Editor tool that converts Realmz scenario text dumps (e.g. *City of Bywater
 full script*) into the project's `map_scriptareas.json` + `map_scripts.gd`
-file pair, one map level at a time.
+file pair, in bulk across all map levels in one click.
 
-## Usage
+## Usage (default — bulk import)
 
 1. Make sure the plugin is enabled (Project → Project Settings → Plugins →
    "Realmz Dump Importer"). It's enabled by default in the committed
@@ -13,23 +13,58 @@ file pair, one map level at a time.
 3. Click **Pick Dump File...** and choose your `.txt` dump.
 4. Set:
    - **Campaign Maps dir** — defaults to `res://Campaigns/City of Bywater/Maps/`.
-   - **Level** — the integer suffix on `map_<N>` you want to populate (e.g. `5`
-     fills `map_5`).
-   - **Kind** — `LAND` for outdoor / interior land maps (matches `LAP<n>/i`
-     entries in the dump), `DUNGEON` for `DAP<n>/i` entries.
-   - **Dry-run** — when on, just prints stats + a preview to the log; doesn't
-     touch disk.
-5. Click **Import**. The log shows AP / RR counts and any unhandled opcodes
-   that were left as `# TODO[<opcode>]:` comments in the GDScript output.
+     Change this to the equivalent path for any other scenario.
+   - **Force overwrite** — leave **off** unless you really want to clobber
+     hand-ported maps. The default skip-if-already-ported heuristic (≥ 20
+     `static func` definitions in the existing `map_scripts.gd`) protects
+     `map_0` and any other map that's been finished.
+   - **Dry-run** — leave **on** for the first run; reports per-map sizes and
+     unhandled-opcode counts without writing anything.
+5. Click **Import All**. The importer:
+   - Parses the dump.
+   - Discovers every `(LAND/DUNGEON, level)` pair that has APs.
+   - Routes `LAND level=N` → `<Campaign Maps>/map_<N>/` and `DUNGEON level=N`
+     → `<Campaign Maps>/mapd_<N>/`.
+   - Reports each map as **DRY-RUN**, **WRITTEN**, **SKIPPED** (with reason),
+     or **ERROR** in a single result table in the log.
 
-## What the importer does
+Example result table for City of Bywater (after the first proper run):
 
-- Parses the dump section by section (headers begin with `===== `).
-- Filters to LAND_AP / DUNGEON_AP / LAND_RR / DUNGEON_RR records for the
-  chosen `level`.
-- Emits one `static func APIDxXyY()` per AP, mirroring the pattern used in the
-  existing `Maps/map_0/map_scripts.gd`.
-- Writes the matching `map_scriptareas.json` rect entries.
+```
+MAP      KIND     APs      RESULT
+map_0    LAND     95       SKIPPED (already ported: 263 funcs ...)
+map_1    LAND     37       WRITTEN (5 unhandled opcodes ...)
+map_2    LAND     12       WRITTEN ...
+map_3    LAND     23       WRITTEN ...
+map_4    LAND     47       WRITTEN ...
+map_5    LAND     97       WRITTEN ...
+map_6    LAND     56       WRITTEN ...
+map_7    LAND     98       WRITTEN ...
+map_8    LAND     97       WRITTEN ...
+mapd_0   DUNGEON  23       WRITTEN ...
+mapd_1   DUNGEON  91       WRITTEN ...
+```
+
+## Single-map mode (advanced)
+
+Tick **Show advanced options → Single-map mode** to import exactly one
+`(level, kind)` instead of iterating the whole dump. Useful when:
+
+- Regenerating one specific map after fixing an opcode translation in the
+  emitter.
+- Testing the emitter against `map_0` without touching the existing hand-port
+  (combine with **Dry-run** + leave **Force overwrite** off).
+
+## Cross-scenario reuse
+
+The dump format is scenario-agnostic. To run on a different scenario:
+
+1. Point **Dump file** at that scenario's text dump.
+2. Point **Campaign Maps dir** at `res://Campaigns/<NewScenario>/Maps/`.
+3. Click **Import All**.
+
+No code changes — the only knob that distinguishes scenarios is the campaign
+root path.
 
 ## Opcode coverage (first cut)
 
@@ -42,22 +77,21 @@ file pair, one map level at a time.
 | `treasure TSR<N>` | `give_treasure_with_id(N)` |
 | `give_map <N>` | `give_minimap(N)` |
 | `sound <N>` | `play_sound_divinity(N)` |
-| `exit_ap` | `return` (terminator added to every AP unconditionally) |
+| `exit_ap` | `return` (terminator added unconditionally to every AP) |
 | Header `to_level=L to_x=X to_y=Y` | leading `teleport_to_map_and_pos_divinity(L, X, Y, 0)` |
 
 Anything else (e.g. `option`, `battle`, `jmp_battle`, `jmp_xap`, `enable_ap`,
-`modify_ap`, `set_dungeon` to a dungeon target, etc.) is emitted as
+`modify_ap`, `set_dungeon` to a dungeon target) is emitted as
 `# TODO[<opcode>]: <raw args>` so the human-translation work is visible
-inline. Add coverage for these in follow-up PRs as their helper-call
-conventions get nailed down.
+inline. Coverage extends opcode-by-opcode in follow-up PRs.
 
 ## Design notes
 
 - The dump has stray null bytes embedded in some string payloads. The parser
-  strips them on read; they're a remnant of the original Realmz binary
-  format leaking into the text export.
-- Output is always rewritten in full; existing files are overwritten.
-  Always use **dry-run** first or have your changes committed.
+  strips them on read; they're a leftover of the binary→text export.
+- Output is always rewritten in full when a map is processed; per-line merges
+  aren't supported. The skip-if-already-ported heuristic plus Dry-run +
+  commit-before-running are the safety net.
 - `Paths` and `Secrets` in the JSON output are emitted as empty arrays. The
-  dump format for those isn't yet plumbed through; preserve them by hand if
-  the target file already has values.
+  dump format for those isn't yet plumbed through; preserve any existing
+  values manually for now.

--- a/src/addons/realmz_dump_importer/README.md
+++ b/src/addons/realmz_dump_importer/README.md
@@ -1,0 +1,63 @@
+# Realmz Dump Importer
+
+Editor tool that converts Realmz scenario text dumps (e.g. *City of Bywater
+full script*) into the project's `map_scriptareas.json` + `map_scripts.gd`
+file pair, one map level at a time.
+
+## Usage
+
+1. Make sure the plugin is enabled (Project → Project Settings → Plugins →
+   "Realmz Dump Importer"). It's enabled by default in the committed
+   `project.godot`.
+2. Open **Project → Tools → Realmz: Import Scenario Dump...**.
+3. Click **Pick Dump File...** and choose your `.txt` dump.
+4. Set:
+   - **Campaign Maps dir** — defaults to `res://Campaigns/City of Bywater/Maps/`.
+   - **Level** — the integer suffix on `map_<N>` you want to populate (e.g. `5`
+     fills `map_5`).
+   - **Kind** — `LAND` for outdoor / interior land maps (matches `LAP<n>/i`
+     entries in the dump), `DUNGEON` for `DAP<n>/i` entries.
+   - **Dry-run** — when on, just prints stats + a preview to the log; doesn't
+     touch disk.
+5. Click **Import**. The log shows AP / RR counts and any unhandled opcodes
+   that were left as `# TODO[<opcode>]:` comments in the GDScript output.
+
+## What the importer does
+
+- Parses the dump section by section (headers begin with `===== `).
+- Filters to LAND_AP / DUNGEON_AP / LAND_RR / DUNGEON_RR records for the
+  chosen `level`.
+- Emits one `static func APIDxXyY()` per AP, mirroring the pattern used in the
+  existing `Maps/map_0/map_scripts.gd`.
+- Writes the matching `map_scriptareas.json` rect entries.
+
+## Opcode coverage (first cut)
+
+| Opcode | Translated to |
+|---|---|
+| `string "..."[, no_wait]` | `display_text_wait_noise(...)` (default sfx `'message nod.wav'`) |
+| `set_dungeon 1(land), level=N, x=X, y=Y, dir=D` | `teleport_to_map_and_pos_divinity(N, X, Y, 0)` |
+| `simple_enc SEC<N>` | `display_simple_encounter_Divinity(N)` |
+| `complex_enc CEC<N>` | `start_complex_encounter_Divinity(N)` |
+| `treasure TSR<N>` | `give_treasure_with_id(N)` |
+| `give_map <N>` | `give_minimap(N)` |
+| `sound <N>` | `play_sound_divinity(N)` |
+| `exit_ap` | `return` (terminator added to every AP unconditionally) |
+| Header `to_level=L to_x=X to_y=Y` | leading `teleport_to_map_and_pos_divinity(L, X, Y, 0)` |
+
+Anything else (e.g. `option`, `battle`, `jmp_battle`, `jmp_xap`, `enable_ap`,
+`modify_ap`, `set_dungeon` to a dungeon target, etc.) is emitted as
+`# TODO[<opcode>]: <raw args>` so the human-translation work is visible
+inline. Add coverage for these in follow-up PRs as their helper-call
+conventions get nailed down.
+
+## Design notes
+
+- The dump has stray null bytes embedded in some string payloads. The parser
+  strips them on read; they're a remnant of the original Realmz binary
+  format leaking into the text export.
+- Output is always rewritten in full; existing files are overwritten.
+  Always use **dry-run** first or have your changes committed.
+- `Paths` and `Secrets` in the JSON output are emitted as empty arrays. The
+  dump format for those isn't yet plumbed through; preserve them by hand if
+  the target file already has values.

--- a/src/addons/realmz_dump_importer/dump_parser.gd
+++ b/src/addons/realmz_dump_importer/dump_parser.gd
@@ -1,0 +1,181 @@
+@tool
+extends RefCounted
+
+## Parser for the City of Bywater scenario text dump. The dump is a sequence of
+## sections, each starting with a line that begins "===== <KIND> ...".
+## Indented lines below a header are opcodes for that section, e.g.:
+##
+##     ===== LAND AP level=0 id=25 x=16 y=17 to_level=5 to_x=21 to_y=5 [LAP0/25]
+##       string                   "...trap door..."#200, no_wait
+##       exit_ap
+##
+## The dump as shipped contains stray null bytes inside string payloads.
+## We strip them on read so downstream regex / split logic doesn't choke.
+##
+## Output schema (per section):
+##     {
+##         "kind"     : "LAND_AP" | "DUNGEON_AP" | "LAND_RR" | "DUNGEON_RR" | "XAP" | ...,
+##         "header"   : original header line (without the "===== " prefix),
+##         "fields"   : parsed key=value attrs from the header (level, id, x, y, ...),
+##         "tag"      : the [LAPN/I] tag from the header (or "" if none),
+##         "opcodes"  : Array of { "name": String, "raw": String, "args": String },
+##     }
+
+const KIND_PATTERNS := {
+	"LAND_AP": "^LAND AP ",
+	"DUNGEON_AP": "^DUNGEON AP ",
+	"LAND_RR": "^LAND RANDOM RECTANGLE ",
+	"DUNGEON_RR": "^DUNGEON RANDOM RECTANGLE ",
+	"XAP": "^XAP ",
+	"LAND_MAP": "^LAND MAP ",
+	"DUNGEON_MAP": "^DUNGEON MAP ",
+	"SIMPLE_ENCOUNTER": "^SIMPLE ENCOUNTER ",
+	"COMPLEX_ENCOUNTER": "^COMPLEX ENCOUNTER ",
+	"ROGUE_ENCOUNTER": "^ROGUE ENCOUNTER ",
+	"BATTLE": "^BATTLE ",
+	"MONSTER": "^MONSTER ",
+	"ITEM": "^ITEM ",
+	"SHOP": "^SHOP ",
+	"TREASURE": "^TREASURE ",
+	"TILESET": "^TILESET ",
+	"GLOBAL_METADATA": "^GLOBAL METADATA",
+	"SCENARIO_METADATA": "^SCENARIO METADATA",
+	"RESTRICTIONS": "^RESTRICTIONS",
+	"NEGATIVE_TILE_PROPERTIES": "^NEGATIVE TILE PROPERTIES",
+}
+
+var sections : Array = []  # Array[Dictionary]
+var errors : Array = []   # Array[String]
+
+func parse_file(path : String) -> bool:
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		errors.append("Could not open dump file: %s (err %d)" % [path, FileAccess.get_open_error()])
+		return false
+	var raw := f.get_buffer(f.get_length())
+	f.close()
+	# Strip null bytes — the dump as shipped has interspersed \0 inside strings.
+	var cleaned := PackedByteArray()
+	cleaned.resize(raw.size())
+	var w := 0
+	for i in range(raw.size()):
+		if raw[i] != 0:
+			cleaned[w] = raw[i]
+			w += 1
+	cleaned.resize(w)
+	# Latin-1 round-trips bytes 1:1 — safer than UTF-8 for files with rare junk.
+	var text := cleaned.get_string_from_ascii()
+	if text.is_empty():
+		# get_string_from_ascii fails on bytes >127. Fall back manually.
+		text = ""
+		for i in range(cleaned.size()):
+			text += char(cleaned[i])
+	return parse_text(text)
+
+func parse_text(text : String) -> bool:
+	sections.clear()
+	# Normalize line endings.
+	text = text.replace("\r\n", "\n").replace("\r", "\n")
+	var lines := text.split("\n", false)
+	var current : Dictionary = {}
+	for line_raw in lines:
+		var line : String = line_raw
+		if line.begins_with("===== "):
+			if not current.is_empty():
+				sections.append(current)
+			current = _parse_header(line.substr(6))
+			current["opcodes"] = []
+		elif current.is_empty():
+			continue  # Skip prelude before first header.
+		else:
+			# Opcode lines start with whitespace.
+			var stripped := line.strip_edges(true, false)
+			if stripped.is_empty():
+				continue
+			# An opcode line: leading whitespace then "name<spaces>args".
+			# Or for RR sections, free-form "key = value" body lines — treat the
+			# whole line as the "raw" value, with name="" (handler-specific).
+			var opc := _parse_opcode_line(line)
+			if opc.size() > 0:
+				current["opcodes"].append(opc)
+	if not current.is_empty():
+		sections.append(current)
+	return true
+
+func _parse_header(after_marker : String) -> Dictionary:
+	# after_marker like: 'LAND AP level=0 id=25 x=16 y=17 to_level=5 to_x=21 to_y=5 [LAP0/25]'
+	var d : Dictionary = {
+		"kind": "",
+		"header": after_marker,
+		"fields": {},
+		"tag": "",
+	}
+	# Pull out the trailing [TAG] if present.
+	var tag_re := RegEx.new()
+	tag_re.compile("\\[([^\\]]+)\\]\\s*$")
+	var tag_match := tag_re.search(after_marker)
+	var body := after_marker
+	if tag_match:
+		d["tag"] = tag_match.get_string(1)
+		body = after_marker.substr(0, tag_match.get_start()).strip_edges()
+	# Identify kind by longest matching prefix.
+	for k in KIND_PATTERNS:
+		var pre : String = KIND_PATTERNS[k]
+		# pre is a regex; for prefix matching just use the literal after stripping ^.
+		var literal : String = pre.trim_prefix("^").trim_suffix(" ")
+		if body == literal or body.begins_with(literal + " ") or body.begins_with(literal):
+			d["kind"] = k
+			body = body.substr(literal.length()).strip_edges()
+			break
+	# Parse remaining "key=value" tokens.
+	var kv_re := RegEx.new()
+	# value may be a quoted string, a number, or an unquoted token (no whitespace, no '=').
+	kv_re.compile('([a-zA-Z_][a-zA-Z0-9_]*)=("(?:[^"\\\\]|\\\\.)*"|[^\\s]+)')
+	for m in kv_re.search_all(body):
+		var key : String = m.get_string(1)
+		var val : String = m.get_string(2)
+		d["fields"][key] = val
+	return d
+
+func _parse_opcode_line(line : String) -> Dictionary:
+	# Match "  <name>   <args>" — name is the first token, args the rest.
+	var stripped := line.strip_edges(true, false)
+	if stripped.is_empty():
+		return {}
+	var sp := stripped.find(" ")
+	var name : String
+	var args : String
+	if sp == -1:
+		name = stripped
+		args = ""
+	else:
+		name = stripped.substr(0, sp)
+		args = stripped.substr(sp + 1).strip_edges(true, false)
+	return {
+		"name": name,
+		"args": args,
+		"raw": stripped,
+	}
+
+# --- Convenience filters ---
+
+func sections_of_kind(kind : String) -> Array:
+	var out : Array = []
+	for s in sections:
+		if s["kind"] == kind:
+			out.append(s)
+	return out
+
+func land_aps_for_level(level : int) -> Array:
+	var out : Array = []
+	for s in sections:
+		if s["kind"] == "LAND_AP" and int(s["fields"].get("level", "-1")) == level:
+			out.append(s)
+	return out
+
+func dungeon_aps_for_level(level : int) -> Array:
+	var out : Array = []
+	for s in sections:
+		if s["kind"] == "DUNGEON_AP" and int(s["fields"].get("level", "-1")) == level:
+			out.append(s)
+	return out

--- a/src/addons/realmz_dump_importer/dump_parser.gd
+++ b/src/addons/realmz_dump_importer/dump_parser.gd
@@ -179,3 +179,37 @@ func dungeon_aps_for_level(level : int) -> Array:
 		if s["kind"] == "DUNGEON_AP" and int(s["fields"].get("level", "-1")) == level:
 			out.append(s)
 	return out
+
+# Enumerate every (kind, level) pair that has at least one AP in the dump.
+# Used by the dialog's "Import All" path to drive a one-click bulk import
+# without making the user remember which levels exist.
+#
+# Returns an Array of dictionaries:
+#   [{"kind": "LAND_AP" | "DUNGEON_AP", "level": int, "ap_count": int}, ...]
+# Sorted by kind (LAND first, DUNGEON second) then by ascending level so the
+# log output reads top-to-bottom in a predictable order.
+func discover_ap_levels() -> Array:
+	# Bucket APs into kind -> level -> count using a nested dict so we can
+	# report the AP count per map alongside the (kind, level) tuple.
+	var counts : Dictionary = {"LAND_AP": {}, "DUNGEON_AP": {}}
+	for s in sections:
+		var kind : String = s["kind"]
+		if not counts.has(kind):
+			continue  # XAP / encounters / monsters / etc. don't drive map files.
+		var level := int(s["fields"].get("level", "-1"))
+		if level < 0:
+			continue  # Defensive — every AP in the dump has a level field.
+		counts[kind][level] = int(counts[kind].get(level, 0)) + 1
+	var out : Array = []
+	# LAND first, then DUNGEON — matches the natural reading order (overworld
+	# before dungeons) and groups results visually in the log.
+	for kind in ["LAND_AP", "DUNGEON_AP"]:
+		var levels : Array = counts[kind].keys()
+		levels.sort()
+		for lvl in levels:
+			out.append({
+				"kind": kind,
+				"level": lvl,
+				"ap_count": counts[kind][lvl],
+			})
+	return out

--- a/src/addons/realmz_dump_importer/dump_parser.gd.uid
+++ b/src/addons/realmz_dump_importer/dump_parser.gd.uid
@@ -1,0 +1,1 @@
+uid://bqujblai5hcoa

--- a/src/addons/realmz_dump_importer/import_dialog.gd
+++ b/src/addons/realmz_dump_importer/import_dialog.gd
@@ -20,6 +20,7 @@ var _log : TextEdit
 var _file_dialog : FileDialog
 
 var _last_emitter
+var _run_count : int = 0
 
 func _init() -> void:
 	title = "Realmz: Import Scenario Dump"
@@ -109,6 +110,9 @@ func _on_dump_picked(path : String) -> void:
 	_log_line("Selected dump: %s" % path)
 
 func _on_confirmed() -> void:
+	# Clear and stamp every run so subsequent clicks produce a visible change.
+	_run_count += 1
+	_log.text = "=== Run #%d @ %s ===" % [_run_count, Time.get_time_string_from_system()]
 	var dump_path := _dump_path_label.text
 	if not FileAccess.file_exists(dump_path):
 		_log_line("ERROR: dump path is not a file: %s" % dump_path)
@@ -171,4 +175,6 @@ func _write_file(path : String, content : String) -> bool:
 
 func _log_line(s : String) -> void:
 	_log.text += "\n" + s
-	_log.scroll_vertical = _log.get_line_count()
+	# scroll_vertical is in pixels in Godot 4; set the caret to the last line
+	# and TextEdit will scroll that line into view automatically.
+	_log.set_caret_line(_log.get_line_count() - 1)

--- a/src/addons/realmz_dump_importer/import_dialog.gd
+++ b/src/addons/realmz_dump_importer/import_dialog.gd
@@ -1,0 +1,174 @@
+@tool
+extends AcceptDialog
+
+const RealmzDumpParser := preload("res://addons/realmz_dump_importer/dump_parser.gd")
+const RealmzScriptEmitter := preload("res://addons/realmz_dump_importer/script_emitter.gd")
+
+## Modal dialog for the Realmz scenario dump importer. Lets the user pick a
+## dump file, choose a target campaign + level + map kind (LAND or DUNGEON),
+## preview what would be written, and either copy the output to the clipboard
+## (dry-run) or write it directly into the campaign's Maps folder.
+
+const DEFAULT_CAMPAIGN_PATH := "res://Campaigns/City of Bywater/Maps/"
+
+var _dump_path_label : Label
+var _campaign_path_edit : LineEdit
+var _level_spin : SpinBox
+var _kind_options : OptionButton  # 0 = LAND, 1 = DUNGEON
+var _dry_run_check : CheckBox
+var _log : TextEdit
+var _file_dialog : FileDialog
+
+var _last_emitter
+
+func _init() -> void:
+	title = "Realmz: Import Scenario Dump"
+	min_size = Vector2(640, 540)
+	dialog_hide_on_ok = false
+	get_ok_button().text = "Import"
+	add_button("Pick Dump File...", true, "pick_file")
+	add_cancel_button("Close")
+
+	var vbox := VBoxContainer.new()
+	add_child(vbox)
+	vbox.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+
+	# Dump path row
+	var dump_row := HBoxContainer.new()
+	vbox.add_child(dump_row)
+	var dump_lbl := Label.new()
+	dump_lbl.text = "Dump file:"
+	dump_lbl.custom_minimum_size = Vector2(120, 0)
+	dump_row.add_child(dump_lbl)
+	_dump_path_label = Label.new()
+	_dump_path_label.text = "(none — click Pick Dump File...)"
+	_dump_path_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	dump_row.add_child(_dump_path_label)
+
+	# Campaign path row
+	var camp_row := HBoxContainer.new()
+	vbox.add_child(camp_row)
+	var camp_lbl := Label.new()
+	camp_lbl.text = "Campaign Maps dir:"
+	camp_lbl.custom_minimum_size = Vector2(120, 0)
+	camp_row.add_child(camp_lbl)
+	_campaign_path_edit = LineEdit.new()
+	_campaign_path_edit.text = DEFAULT_CAMPAIGN_PATH
+	_campaign_path_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	camp_row.add_child(_campaign_path_edit)
+
+	# Level / Kind row
+	var sel_row := HBoxContainer.new()
+	vbox.add_child(sel_row)
+	var lvl_lbl := Label.new()
+	lvl_lbl.text = "Level:"
+	lvl_lbl.custom_minimum_size = Vector2(120, 0)
+	sel_row.add_child(lvl_lbl)
+	_level_spin = SpinBox.new()
+	_level_spin.min_value = 0
+	_level_spin.max_value = 20
+	_level_spin.value = 5
+	sel_row.add_child(_level_spin)
+	_kind_options = OptionButton.new()
+	_kind_options.add_item("LAND (outdoor / interior)", 0)
+	_kind_options.add_item("DUNGEON", 1)
+	_kind_options.selected = 0
+	sel_row.add_child(_kind_options)
+
+	# Dry-run row
+	_dry_run_check = CheckBox.new()
+	_dry_run_check.text = "Dry-run (preview only — print to log, don't write files)"
+	_dry_run_check.button_pressed = true
+	vbox.add_child(_dry_run_check)
+
+	# Log
+	_log = TextEdit.new()
+	_log.editable = false
+	_log.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_log.text = "Ready. Pick a dump file and choose Import."
+	vbox.add_child(_log)
+
+	# File dialog
+	_file_dialog = FileDialog.new()
+	_file_dialog.access = FileDialog.ACCESS_FILESYSTEM
+	_file_dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
+	_file_dialog.add_filter("*.txt", "Text dump")
+	_file_dialog.add_filter("*", "All files")
+	_file_dialog.file_selected.connect(_on_dump_picked)
+	add_child(_file_dialog)
+
+	custom_action.connect(_on_custom_action)
+	confirmed.connect(_on_confirmed)
+
+func _on_custom_action(action : StringName) -> void:
+	if String(action) == "pick_file":
+		_file_dialog.popup_centered_ratio(0.7)
+
+func _on_dump_picked(path : String) -> void:
+	_dump_path_label.text = path
+	_log_line("Selected dump: %s" % path)
+
+func _on_confirmed() -> void:
+	var dump_path := _dump_path_label.text
+	if not FileAccess.file_exists(dump_path):
+		_log_line("ERROR: dump path is not a file: %s" % dump_path)
+		return
+
+	var parser := RealmzDumpParser.new()
+	_log_line("Parsing %s ..." % dump_path)
+	if not parser.parse_file(dump_path):
+		for e in parser.errors:
+			_log_line("  parse error: %s" % e)
+		return
+	_log_line("  -> %d sections parsed" % parser.sections.size())
+
+	var emitter := RealmzScriptEmitter.new()
+	var level := int(_level_spin.value)
+	var dungeon := _kind_options.get_selected_id() == 1
+	emitter.emit(parser, level, dungeon)
+	_last_emitter = emitter
+
+	_log_line("APs for %s level=%d: %d   RRs: %d" % ["DUNGEON" if dungeon else "LAND", level, emitter.aps.size(), emitter.rrs.size()])
+	if emitter.unhandled_opcodes.size() > 0:
+		_log_line("Unhandled opcodes (left as TODO comments):")
+		var keys := emitter.unhandled_opcodes.keys()
+		keys.sort()
+		for k in keys:
+			_log_line("  %s : %d occurrences" % [k, emitter.unhandled_opcodes[k]])
+
+	var camp_dir := _campaign_path_edit.text.rstrip("/")
+	var map_folder := "%s/map_%d" % [camp_dir, level]
+	var json_path := "%s/map_scriptareas.json" % map_folder
+	var gd_path := "%s/map_scripts.gd" % map_folder
+
+	if _dry_run_check.button_pressed:
+		_log_line("Dry-run: would write %s (%d bytes)" % [json_path, emitter.json_text.length()])
+		_log_line("Dry-run: would write %s (%d bytes)" % [gd_path, emitter.gd_text.length()])
+		_log_line("--- map_scriptareas.json preview (first 800 chars) ---")
+		_log_line(emitter.json_text.substr(0, 800))
+		_log_line("--- map_scripts.gd preview (first 800 chars) ---")
+		_log_line(emitter.gd_text.substr(0, 800))
+		return
+
+	if not DirAccess.dir_exists_absolute(ProjectSettings.globalize_path(map_folder)):
+		_log_line("ERROR: target folder does not exist: %s" % map_folder)
+		return
+
+	if not _write_file(json_path, emitter.json_text):
+		return
+	if not _write_file(gd_path, emitter.gd_text):
+		return
+	_log_line("Wrote %s and %s. Resave the open scene / re-enter map to refresh." % [json_path, gd_path])
+
+func _write_file(path : String, content : String) -> bool:
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	if f == null:
+		_log_line("ERROR: could not open %s for writing (err %d)" % [path, FileAccess.get_open_error()])
+		return false
+	f.store_string(content)
+	f.close()
+	return true
+
+func _log_line(s : String) -> void:
+	_log.text += "\n" + s
+	_log.scroll_vertical = _log.get_line_count()

--- a/src/addons/realmz_dump_importer/import_dialog.gd
+++ b/src/addons/realmz_dump_importer/import_dialog.gd
@@ -4,29 +4,52 @@ extends AcceptDialog
 const RealmzDumpParser := preload("res://addons/realmz_dump_importer/dump_parser.gd")
 const RealmzScriptEmitter := preload("res://addons/realmz_dump_importer/script_emitter.gd")
 
-## Modal dialog for the Realmz scenario dump importer. Lets the user pick a
-## dump file, choose a target campaign + level + map kind (LAND or DUNGEON),
-## preview what would be written, and either copy the output to the clipboard
-## (dry-run) or write it directly into the campaign's Maps folder.
+## Modal dialog for the Realmz scenario dump importer.
+##
+## Default flow ("Import All"):
+##   1. User picks a dump file + campaign Maps dir.
+##   2. Parser auto-discovers every (LAND/DUNGEON, level) pair with APs.
+##   3. For each pair, route LAND -> map_<N>/, DUNGEON -> mapd_<N>/.
+##   4. Skip already-ported maps (heuristic: existing map_scripts.gd has many
+##      `static func` defs) unless "Force overwrite" is on. This protects the
+##      hand-ported map_0 by default.
+##   5. Each map's outcome (WRITTEN / SKIPPED / ERROR) is summarised in a log
+##      table.
+##
+## Advanced mode (toggle reveals controls): single-map override for cases where
+## a maintainer wants to regenerate one specific level instead of the whole set.
 
 const DEFAULT_CAMPAIGN_PATH := "res://Campaigns/City of Bywater/Maps/"
 
+# Threshold for the "this map is already ported, don't clobber it" heuristic.
+# map_0 has 95 LAP funcs + 168 XAP funcs (263 total) so anything well past the
+# scaffolding count is treated as a hand-port we should preserve. Maps that the
+# importer itself has filled previously will have AP-count-many funcs (e.g. 97
+# for map_5), so the threshold also keeps generated content stable across
+# re-runs. "Force overwrite" bypasses this.
+const ALREADY_PORTED_FUNC_THRESHOLD := 20
+
 var _dump_path_label : Label
 var _campaign_path_edit : LineEdit
+var _force_overwrite_check : CheckBox
+var _dry_run_check : CheckBox
+var _advanced_toggle : CheckBox
+var _advanced_panel : VBoxContainer
+var _single_map_check : CheckBox
 var _level_spin : SpinBox
 var _kind_options : OptionButton  # 0 = LAND, 1 = DUNGEON
-var _dry_run_check : CheckBox
 var _log : TextEdit
 var _file_dialog : FileDialog
 
-var _last_emitter
 var _run_count : int = 0
 
 func _init() -> void:
 	title = "Realmz: Import Scenario Dump"
-	min_size = Vector2(640, 540)
+	min_size = Vector2(720, 600)
+	# Stay open after a click — the user often wants to tweak settings and
+	# re-run, or read the log table after the import finishes.
 	dialog_hide_on_ok = false
-	get_ok_button().text = "Import"
+	get_ok_button().text = "Import All"
 	add_button("Pick Dump File...", true, "pick_file")
 	add_cancel_button("Close")
 
@@ -34,62 +57,42 @@ func _init() -> void:
 	add_child(vbox)
 	vbox.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 
-	# Dump path row
-	var dump_row := HBoxContainer.new()
-	vbox.add_child(dump_row)
-	var dump_lbl := Label.new()
-	dump_lbl.text = "Dump file:"
-	dump_lbl.custom_minimum_size = Vector2(120, 0)
-	dump_row.add_child(dump_lbl)
-	_dump_path_label = Label.new()
-	_dump_path_label.text = "(none — click Pick Dump File...)"
-	_dump_path_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	dump_row.add_child(_dump_path_label)
+	# --- Inputs ---
+	vbox.add_child(_make_path_row("Dump file:", "(none — click Pick Dump File...)", true))
+	vbox.add_child(_make_campaign_row())
 
-	# Campaign path row
-	var camp_row := HBoxContainer.new()
-	vbox.add_child(camp_row)
-	var camp_lbl := Label.new()
-	camp_lbl.text = "Campaign Maps dir:"
-	camp_lbl.custom_minimum_size = Vector2(120, 0)
-	camp_row.add_child(camp_lbl)
-	_campaign_path_edit = LineEdit.new()
-	_campaign_path_edit.text = DEFAULT_CAMPAIGN_PATH
-	_campaign_path_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	camp_row.add_child(_campaign_path_edit)
+	# Force-overwrite is OFF by default — a fresh contributor running the
+	# importer should not be one click away from wiping the hand-ported map_0.
+	_force_overwrite_check = CheckBox.new()
+	_force_overwrite_check.text = "Force overwrite (bypass already-ported skip — DANGEROUS for map_0)"
+	_force_overwrite_check.button_pressed = false
+	vbox.add_child(_force_overwrite_check)
 
-	# Level / Kind row
-	var sel_row := HBoxContainer.new()
-	vbox.add_child(sel_row)
-	var lvl_lbl := Label.new()
-	lvl_lbl.text = "Level:"
-	lvl_lbl.custom_minimum_size = Vector2(120, 0)
-	sel_row.add_child(lvl_lbl)
-	_level_spin = SpinBox.new()
-	_level_spin.min_value = 0
-	_level_spin.max_value = 20
-	_level_spin.value = 5
-	sel_row.add_child(_level_spin)
-	_kind_options = OptionButton.new()
-	_kind_options.add_item("LAND (outdoor / interior)", 0)
-	_kind_options.add_item("DUNGEON", 1)
-	_kind_options.selected = 0
-	sel_row.add_child(_kind_options)
-
-	# Dry-run row
+	# Dry-run is ON by default — user sees a preview before committing to disk.
 	_dry_run_check = CheckBox.new()
 	_dry_run_check.text = "Dry-run (preview only — print to log, don't write files)"
 	_dry_run_check.button_pressed = true
 	vbox.add_child(_dry_run_check)
 
-	# Log
+	# Advanced toggle — hides the per-map controls in the default flow so the
+	# UI surface for "import everything" is just two paths and two checkboxes.
+	_advanced_toggle = CheckBox.new()
+	_advanced_toggle.text = "Show advanced options (single-map mode)"
+	_advanced_toggle.toggled.connect(_on_advanced_toggled)
+	vbox.add_child(_advanced_toggle)
+
+	_advanced_panel = _build_advanced_panel()
+	_advanced_panel.visible = false  # Hidden until the toggle is checked.
+	vbox.add_child(_advanced_panel)
+
+	# --- Log ---
 	_log = TextEdit.new()
 	_log.editable = false
 	_log.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	_log.text = "Ready. Pick a dump file and choose Import."
+	_log.text = "Ready. Pick a dump file and choose Import All (or enable advanced mode for single-map)."
 	vbox.add_child(_log)
 
-	# File dialog
+	# --- File picker ---
 	_file_dialog = FileDialog.new()
 	_file_dialog.access = FileDialog.ACCESS_FILESYSTEM
 	_file_dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
@@ -101,7 +104,74 @@ func _init() -> void:
 	custom_action.connect(_on_custom_action)
 	confirmed.connect(_on_confirmed)
 
+# --- UI builders ----------------------------------------------------
+
+func _make_path_row(label_text : String, default_value : String, is_dump_path : bool) -> HBoxContainer:
+	var row := HBoxContainer.new()
+	var lbl := Label.new()
+	lbl.text = label_text
+	lbl.custom_minimum_size = Vector2(140, 0)
+	row.add_child(lbl)
+	if is_dump_path:
+		_dump_path_label = Label.new()
+		_dump_path_label.text = default_value
+		_dump_path_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		row.add_child(_dump_path_label)
+	return row
+
+func _make_campaign_row() -> HBoxContainer:
+	var row := HBoxContainer.new()
+	var lbl := Label.new()
+	lbl.text = "Campaign Maps dir:"
+	lbl.custom_minimum_size = Vector2(140, 0)
+	row.add_child(lbl)
+	_campaign_path_edit = LineEdit.new()
+	_campaign_path_edit.text = DEFAULT_CAMPAIGN_PATH
+	_campaign_path_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	# Tooltip clarifies the cross-scenario reuse story: just point this at a
+	# different scenario's Maps folder and the importer works for it too.
+	_campaign_path_edit.tooltip_text = "Root containing the map_<N> / mapd_<N> folders. Change this to import a different scenario."
+	row.add_child(_campaign_path_edit)
+	return row
+
+func _build_advanced_panel() -> VBoxContainer:
+	var panel := VBoxContainer.new()
+	# Divider so the advanced section visually separates from the main flow.
+	var sep := HSeparator.new()
+	panel.add_child(sep)
+
+	_single_map_check = CheckBox.new()
+	_single_map_check.text = "Single-map mode (only import the chosen level + kind below)"
+	_single_map_check.button_pressed = false
+	panel.add_child(_single_map_check)
+
+	var sel_row := HBoxContainer.new()
+	panel.add_child(sel_row)
+	var lvl_lbl := Label.new()
+	lvl_lbl.text = "Level:"
+	lvl_lbl.custom_minimum_size = Vector2(140, 0)
+	sel_row.add_child(lvl_lbl)
+	_level_spin = SpinBox.new()
+	_level_spin.min_value = 0
+	_level_spin.max_value = 20
+	_level_spin.value = 5
+	sel_row.add_child(_level_spin)
+	_kind_options = OptionButton.new()
+	_kind_options.add_item("LAND (-> map_<N>/)", 0)
+	_kind_options.add_item("DUNGEON (-> mapd_<N>/)", 1)
+	_kind_options.selected = 0
+	sel_row.add_child(_kind_options)
+
+	return panel
+
+# --- Signal handlers -------------------------------------------------
+
+func _on_advanced_toggled(pressed : bool) -> void:
+	_advanced_panel.visible = pressed
+
 func _on_custom_action(action : StringName) -> void:
+	# The "Pick Dump File..." button is registered as a custom action on the
+	# dialog; this routes it to the file picker.
 	if String(action) == "pick_file":
 		_file_dialog.popup_centered_ratio(0.7)
 
@@ -110,14 +180,19 @@ func _on_dump_picked(path : String) -> void:
 	_log_line("Selected dump: %s" % path)
 
 func _on_confirmed() -> void:
-	# Clear and stamp every run so subsequent clicks produce a visible change.
+	# Stamp every run so a user clicking Import N times always sees a visible
+	# change in the log even when results are identical to the previous run.
 	_run_count += 1
 	_log.text = "=== Run #%d @ %s ===" % [_run_count, Time.get_time_string_from_system()]
+
 	var dump_path := _dump_path_label.text
 	if not FileAccess.file_exists(dump_path):
 		_log_line("ERROR: dump path is not a file: %s" % dump_path)
 		return
 
+	# Parse the dump once. The parser builds a list of section records covering
+	# the whole file (~38k lines for CoB). Re-using one parser instance for all
+	# (kind, level) emits is much cheaper than re-reading the file per map.
 	var parser := RealmzDumpParser.new()
 	_log_line("Parsing %s ..." % dump_path)
 	if not parser.parse_file(dump_path):
@@ -126,48 +201,123 @@ func _on_confirmed() -> void:
 		return
 	_log_line("  -> %d sections parsed" % parser.sections.size())
 
-	var emitter := RealmzScriptEmitter.new()
-	var level := int(_level_spin.value)
-	var dungeon := _kind_options.get_selected_id() == 1
-	emitter.emit(parser, level, dungeon)
-	_last_emitter = emitter
-
-	_log_line("APs for %s level=%d: %d   RRs: %d" % ["DUNGEON" if dungeon else "LAND", level, emitter.aps.size(), emitter.rrs.size()])
-	if emitter.unhandled_opcodes.size() > 0:
-		_log_line("Unhandled opcodes (left as TODO comments):")
-		var keys := emitter.unhandled_opcodes.keys()
-		keys.sort()
-		for k in keys:
-			_log_line("  %s : %d occurrences" % [k, emitter.unhandled_opcodes[k]])
-
-	var camp_dir := _campaign_path_edit.text.rstrip("/")
-	var map_folder := "%s/map_%d" % [camp_dir, level]
-	var json_path := "%s/map_scriptareas.json" % map_folder
-	var gd_path := "%s/map_scripts.gd" % map_folder
-
-	if _dry_run_check.button_pressed:
-		_log_line("Dry-run: would write %s (%d bytes)" % [json_path, emitter.json_text.length()])
-		_log_line("Dry-run: would write %s (%d bytes)" % [gd_path, emitter.gd_text.length()])
-		_log_line("--- map_scriptareas.json preview (first 800 chars) ---")
-		_log_line(emitter.json_text.substr(0, 800))
-		_log_line("--- map_scripts.gd preview (first 800 chars) ---")
-		_log_line(emitter.gd_text.substr(0, 800))
+	# Decide which (kind, level) pairs to process. Single-map mode emits exactly
+	# one tuple; the default mode auto-discovers everything in the dump.
+	var targets : Array = _resolve_targets(parser)
+	if targets.is_empty():
+		_log_line("Nothing to import — the dump has no APs for the requested target(s).")
 		return
 
+	var camp_dir : String = _campaign_path_edit.text.rstrip("/")
+	var force : bool = _force_overwrite_check.button_pressed
+	var dry_run : bool = _dry_run_check.button_pressed
+	_log_line("Mode: %s%s" % ["DRY-RUN " if dry_run else "WRITE ", "(force overwrite)" if force else "(skip already-ported)"])
+	_log_line("")  # Blank line before the result table.
+	_log_line("%-8s %-8s %-8s %s" % ["MAP", "KIND", "APs", "RESULT"])
+
+	# Process each target. We always do this in a loop even when there's only
+	# one target (single-map mode) so the result-table rendering and skip logic
+	# stay identical — fewer code paths means fewer bugs.
+	for t in targets:
+		_process_one(parser, t, camp_dir, force, dry_run)
+
+	_log_line("")
+	_log_line("Done.")
+
+# --- Core import -----------------------------------------------------
+
+# Build the list of (kind, level) targets to process. Either the single-map
+# selection from the advanced panel, or every level in the dump.
+func _resolve_targets(parser) -> Array:
+	if _advanced_toggle.button_pressed and _single_map_check.button_pressed:
+		var kind_id : int = _kind_options.get_selected_id()
+		# Map the OptionButton id back to the same string the parser uses so the
+		# same downstream code handles both single-map and import-all paths.
+		var kind_str : String = "LAND_AP" if kind_id == 0 else "DUNGEON_AP"
+		var level := int(_level_spin.value)
+		var ap_list : Array = parser.land_aps_for_level(level) if kind_id == 0 else parser.dungeon_aps_for_level(level)
+		return [{"kind": kind_str, "level": level, "ap_count": ap_list.size()}]
+	# Default: discover every (kind, level) the dump declares APs for.
+	return parser.discover_ap_levels()
+
+func _process_one(parser, target : Dictionary, camp_dir : String, force : bool, dry_run : bool) -> void:
+	var kind_str : String = target["kind"]
+	var level : int = target["level"]
+	var ap_count : int = target["ap_count"]
+	var dungeon : bool = kind_str == "DUNGEON_AP"
+
+	# Folder convention:
+	#   LAND  level=N -> map_<N>/   (overworld + interior land maps)
+	#   DUNGEON level=N -> mapd_<N>/ (proper dungeons)
+	# This matches the existing project layout: map_0..map_8 are LAND, mapd_0
+	# and mapd_1 are DUNGEON. Other scenarios may have different counts but the
+	# same folder convention.
+	var folder_name : String = ("mapd_%d" if dungeon else "map_%d") % level
+	var map_folder : String = "%s/%s" % [camp_dir, folder_name]
+	var json_path : String = "%s/map_scriptareas.json" % map_folder
+	var gd_path : String = "%s/map_scripts.gd" % map_folder
+
+	# Run the emitter for this (level, kind). Each call rebuilds json_text +
+	# gd_text on the emitter; we sample those right after.
+	var emitter := RealmzScriptEmitter.new()
+	emitter.emit(parser, level, dungeon)
+
+	var label : String = "%-8s %-8s %-8d" % [folder_name, "DUNGEON" if dungeon else "LAND", ap_count]
+
+	# Skip-if-already-ported gate. Reads the existing map_scripts.gd and counts
+	# `static func` defs; if it's well past the scaffolding count, assume the
+	# map has been hand-ported (or generated previously) and don't clobber.
+	if not force and not dry_run:
+		var existing_funcs : int = _count_existing_funcs(gd_path)
+		if existing_funcs >= ALREADY_PORTED_FUNC_THRESHOLD:
+			_log_line("%s SKIPPED (already ported: %d funcs — use Force overwrite to regenerate)" % [label, existing_funcs])
+			return
+
+	if dry_run:
+		# Per-target dry-run line — no file is touched, but we report the size
+		# of what would have been written so the user can spot suspiciously
+		# small or empty outputs.
+		_log_line("%s DRY-RUN (json %d B, gd %d B; %d unhandled opcodes)" % [
+			label, emitter.json_text.length(), emitter.gd_text.length(), emitter.unhandled_opcodes.size()
+		])
+		return
+
+	# Make sure the target map folder exists. We don't auto-create it: if the
+	# project doesn't have a map_<N> folder, that's a project-layout question
+	# the importer shouldn't silently answer.
 	if not DirAccess.dir_exists_absolute(ProjectSettings.globalize_path(map_folder)):
-		_log_line("ERROR: target folder does not exist: %s" % map_folder)
+		_log_line("%s ERROR (target folder missing: %s)" % [label, map_folder])
 		return
 
 	if not _write_file(json_path, emitter.json_text):
+		_log_line("%s ERROR (could not write %s)" % [label, json_path])
 		return
 	if not _write_file(gd_path, emitter.gd_text):
+		_log_line("%s ERROR (could not write %s)" % [label, gd_path])
 		return
-	_log_line("Wrote %s and %s. Resave the open scene / re-enter map to refresh." % [json_path, gd_path])
+	_log_line("%s WRITTEN (%d unhandled opcodes left as TODO comments)" % [label, emitter.unhandled_opcodes.size()])
+
+# Count `static func` definitions in an existing map_scripts.gd. Used by the
+# already-ported skip heuristic — the count is a coarse proxy for "has someone
+# put real work into this file".
+func _count_existing_funcs(path : String) -> int:
+	if not FileAccess.file_exists(path):
+		return 0
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		return 0
+	var content : String = f.get_as_text()
+	f.close()
+	# Multiline regex: every line that starts with `static func` counts as one
+	# function. This catches both APs and XAPs in the existing hand-port.
+	var re := RegEx.new()
+	re.compile("(?m)^static func ")
+	return re.search_all(content).size()
 
 func _write_file(path : String, content : String) -> bool:
 	var f := FileAccess.open(path, FileAccess.WRITE)
 	if f == null:
-		_log_line("ERROR: could not open %s for writing (err %d)" % [path, FileAccess.get_open_error()])
+		_log_line("  open-for-write failed (%s, err %d)" % [path, FileAccess.get_open_error()])
 		return false
 	f.store_string(content)
 	f.close()
@@ -175,6 +325,6 @@ func _write_file(path : String, content : String) -> bool:
 
 func _log_line(s : String) -> void:
 	_log.text += "\n" + s
-	# scroll_vertical is in pixels in Godot 4; set the caret to the last line
-	# and TextEdit will scroll that line into view automatically.
+	# scroll_vertical is in pixels in Godot 4; positioning the caret on the
+	# last line is the reliable way to keep newest output visible.
 	_log.set_caret_line(_log.get_line_count() - 1)

--- a/src/addons/realmz_dump_importer/import_dialog.gd
+++ b/src/addons/realmz_dump_importer/import_dialog.gd
@@ -267,19 +267,27 @@ func _process_one(parser, target : Dictionary, camp_dir : String, force : bool, 
 	# Skip-if-already-ported gate. Reads the existing map_scripts.gd and counts
 	# `static func` defs; if it's well past the scaffolding count, assume the
 	# map has been hand-ported (or generated previously) and don't clobber.
-	if not force and not dry_run:
-		var existing_funcs : int = _count_existing_funcs(gd_path)
-		if existing_funcs >= ALREADY_PORTED_FUNC_THRESHOLD:
-			_log_line("%s SKIPPED (already ported: %d funcs — use Force overwrite to regenerate)" % [label, existing_funcs])
-			return
+	# We evaluate this in dry-run too so the user can see exactly which maps
+	# *would* be skipped on a real run — making the dry-run output predictive
+	# rather than just a size dump.
+	var existing_funcs : int = _count_existing_funcs(gd_path)
+	var would_skip : bool = (not force) and existing_funcs >= ALREADY_PORTED_FUNC_THRESHOLD
 
 	if dry_run:
 		# Per-target dry-run line — no file is touched, but we report the size
-		# of what would have been written so the user can spot suspiciously
-		# small or empty outputs.
-		_log_line("%s DRY-RUN (json %d B, gd %d B; %d unhandled opcodes)" % [
-			label, emitter.json_text.length(), emitter.gd_text.length(), emitter.unhandled_opcodes.size()
-		])
+		# of what would have been written and whether the skip gate would have
+		# prevented the write so the user can spot suspiciously small outputs
+		# AND know which maps the real run will leave alone.
+		if would_skip:
+			_log_line("%s WOULD-SKIP (already ported: %d funcs)" % [label, existing_funcs])
+		else:
+			_log_line("%s DRY-RUN (json %d B, gd %d B; %d unhandled opcodes)" % [
+				label, emitter.json_text.length(), emitter.gd_text.length(), emitter.unhandled_opcodes.size()
+			])
+		return
+
+	if would_skip:
+		_log_line("%s SKIPPED (already ported: %d funcs — use Force overwrite to regenerate)" % [label, existing_funcs])
 		return
 
 	# Make sure the target map folder exists. We don't auto-create it: if the

--- a/src/addons/realmz_dump_importer/import_dialog.gd.uid
+++ b/src/addons/realmz_dump_importer/import_dialog.gd.uid
@@ -1,0 +1,1 @@
+uid://brdklgcblqtdm

--- a/src/addons/realmz_dump_importer/plugin.cfg
+++ b/src/addons/realmz_dump_importer/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Realmz Dump Importer"
+description="Editor tool that imports City of Bywater scenario dumps into map_scriptareas.json + map_scripts.gd. Adds a 'Project > Tools > Realmz: Import Scenario Dump...' menu entry."
+author="Realmz Castle"
+version="0.1"
+script="plugin.gd"

--- a/src/addons/realmz_dump_importer/plugin.gd
+++ b/src/addons/realmz_dump_importer/plugin.gd
@@ -1,0 +1,31 @@
+@tool
+extends EditorPlugin
+
+## Realmz: Import Scenario Dump
+##
+## Adds a "Realmz: Import Scenario Dump..." entry under Project > Tools that
+## opens a dialog for converting a City of Bywater (or compatible) text dump
+## into map_scriptareas.json + map_scripts.gd files for a chosen map level.
+##
+## See README.md in this folder for usage and the opcode coverage table.
+
+const RealmzImportDialog := preload("res://addons/realmz_dump_importer/import_dialog.gd")
+
+const MENU_ITEM_LABEL := "Realmz: Import Scenario Dump..."
+
+var _dialog
+
+func _enter_tree() -> void:
+	add_tool_menu_item(MENU_ITEM_LABEL, _on_menu_item_pressed)
+
+func _exit_tree() -> void:
+	remove_tool_menu_item(MENU_ITEM_LABEL)
+	if _dialog and is_instance_valid(_dialog):
+		_dialog.queue_free()
+		_dialog = null
+
+func _on_menu_item_pressed() -> void:
+	if _dialog == null or not is_instance_valid(_dialog):
+		_dialog = RealmzImportDialog.new()
+		EditorInterface.get_base_control().add_child(_dialog)
+	_dialog.popup_centered_ratio(0.6)

--- a/src/addons/realmz_dump_importer/plugin.gd.uid
+++ b/src/addons/realmz_dump_importer/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://bi4leikglwqxx

--- a/src/addons/realmz_dump_importer/script_emitter.gd
+++ b/src/addons/realmz_dump_importer/script_emitter.gd
@@ -1,0 +1,272 @@
+@tool
+extends RefCounted
+
+const RealmzDumpParser := preload("res://addons/realmz_dump_importer/dump_parser.gd")
+
+## Emits map_scriptareas.json + map_scripts.gd from parsed RealmzDumpParser
+## sections, for one map level at a time.
+##
+## This first cut handles the most common opcodes one-to-one against helpers
+## already in scripts/ScriptHelperFuncs.gd:
+##
+##   string                   -> display_text_wait_noise
+##   set_dungeon (land target) -> teleport_to_map_and_pos_divinity
+##   simple_enc               -> display_simple_encounter_Divinity
+##   complex_enc              -> start_complex_encounter_Divinity
+##   treasure                 -> give_treasure_with_id
+##   give_map                 -> give_minimap
+##   sound                    -> play_sound_divinity
+##   exit_ap                  -> return
+##
+## Anything else is emitted as a `# TODO[<opcode>]: <raw args>` line so a
+## reviewer can spot exactly what still needs hand-translation. The output is
+## meant to be a faithful starting point that compiles, not a finished port.
+
+const APS_HEADER := "#Map test Script generated from old AP format"
+const SFX_DEFAULT := "'message nod.wav'"
+
+var aps : Array = []          # parsed LAND_AP / DUNGEON_AP records for the chosen level
+var rrs : Array = []          # parsed LAND_RR / DUNGEON_RR records for the chosen level
+var paths : Array = []        # passthrough — currently empty for new maps
+var secrets : Array = []      # passthrough — currently empty for new maps
+
+var json_text : String = ""
+var gd_text : String = ""
+var unhandled_opcodes : Dictionary = {}  # name -> count (for reporter)
+
+func emit(parser, level : int, dungeon : bool) -> void:
+	if dungeon:
+		aps = parser.dungeon_aps_for_level(level)
+		rrs = _filter_rrs(parser, level, "DUNGEON_RR")
+	else:
+		aps = parser.land_aps_for_level(level)
+		rrs = _filter_rrs(parser, level, "LAND_RR")
+	json_text = _build_scriptareas_json()
+	gd_text = _build_scripts_gd()
+
+func _filter_rrs(parser, level : int, kind : String) -> Array:
+	var out : Array = []
+	for s in parser.sections:
+		if s["kind"] == kind and int(s["fields"].get("level", "-1")) == level:
+			out.append(s)
+	return out
+
+# ------------------------------------------------------------------
+# JSON output
+# ------------------------------------------------------------------
+
+func _build_scriptareas_json() -> String:
+	# Match the human-readable indentation style used in existing map_5/map_scriptareas.json.
+	var lines : Array[String] = []
+	lines.append("{")
+	lines.append("")
+	lines.append("\"ScriptRects\" : {")
+	var entries : Array[String] = []
+	for ap in aps:
+		entries.append(_json_entry_for_ap(ap))
+	for rr in rrs:
+		entries.append(_json_entry_for_rr(rr))
+	lines.append(",\n".join(entries))
+	lines.append("},")
+	lines.append('"Paths" : %s,' % JSON.stringify(paths))
+	lines.append('"Secrets" : %s' % JSON.stringify(secrets))
+	lines.append("}")
+	return "\n".join(lines) + "\n"
+
+func _json_entry_for_ap(ap : Dictionary) -> String:
+	var id_str := str(ap["fields"].get("id", "?"))
+	var x := int(ap["fields"].get("x", "0"))
+	var y := int(ap["fields"].get("y", "0"))
+	var name := "AP%sx%dy%d" % [id_str, x, y]
+	return "   \"%s\":\n   {\n      \"scriptRectangle\": [ [%d,%d], [%d,%d] ],\n      \"scriptToLoad\": \"%s\"\n   }" % [name, x, y, x, y, name]
+
+func _json_entry_for_rr(rr : Dictionary) -> String:
+	var lvl := int(rr["fields"].get("level", "0"))
+	var id_str := str(rr["fields"].get("id", "?"))
+	var x1 := int(rr["fields"].get("x1", "0"))
+	var y1 := int(rr["fields"].get("y1", "0"))
+	var x2 := int(rr["fields"].get("x2", "0"))
+	var y2 := int(rr["fields"].get("y2", "0"))
+	# chance="75/10000" — convert to float fraction.
+	var chance_raw := str(rr["fields"].get("chance", "0/10000")).trim_prefix("\"").trim_suffix("\"")
+	var chance := _parse_chance(chance_raw)
+	var name := "LRR%d.%s" % [lvl, id_str]
+	# RR_Battle body — the parser stored each opcode line; for RRs the whole body
+	# is "battle_range = [a,b], option_chance = N%, ..." which we leave as a TODO
+	# for the human importer phase. Just emit the rect + chance for now.
+	return "   \"%s\":\n   {\n      \"scriptRectangle\": [ [%d,%d], [%d,%d] ],\n      \"chance\": %s,\n      \"scriptToLoad\": []\n   }" % [name, x1, y1, x2, y2, str(chance)]
+
+func _parse_chance(raw : String) -> float:
+	# "75/10000" -> 0.0075
+	var parts := raw.split("/")
+	if parts.size() == 2 and parts[0].is_valid_int() and parts[1].is_valid_int():
+		var num := parts[0].to_int()
+		var den := parts[1].to_int()
+		if den != 0:
+			return float(num) / float(den)
+	return 0.0
+
+# ------------------------------------------------------------------
+# GDScript output
+# ------------------------------------------------------------------
+
+func _build_scripts_gd() -> String:
+	unhandled_opcodes.clear()
+	var lines : Array[String] = []
+	lines.append(APS_HEADER)
+	lines.append("")
+	lines.append("static func _on_map_load(_map) :")
+	lines.append("\tprint(\"mapscript _on_map_load() !!! \")")
+	lines.append("\t# Add any initialization code here")
+	lines.append("")
+	for ap in aps:
+		lines.append_array(_emit_ap(ap))
+		lines.append("")
+	return "\n".join(lines)
+
+func _emit_ap(ap : Dictionary) -> Array:
+	var id_str := str(ap["fields"].get("id", "?"))
+	var x := int(ap["fields"].get("x", "0"))
+	var y := int(ap["fields"].get("y", "0"))
+	var name := "AP%sx%dy%d" % [id_str, x, y]
+	var lines : Array = []
+	lines.append("static func %s() : #%s at %d,%d" % [name, id_str, x, y])
+	# If the AP has a to_level/to_x/to_y header, emit a teleport hint comment.
+	var fields : Dictionary = ap["fields"]
+	if fields.has("to_level") and fields.has("to_x") and fields.has("to_y"):
+		lines.append("\t# Header teleport: to_level=%s to_x=%s to_y=%s" % [fields["to_level"], fields["to_x"], fields["to_y"]])
+		lines.append("\tScriptHelperFuncsClass.teleport_to_map_and_pos_divinity(%s, %s, %s, 0)" % [fields["to_level"], fields["to_x"], fields["to_y"]])
+	var emitted_anything := fields.has("to_level")
+	for opc in ap["opcodes"]:
+		var rendered := _emit_opcode(opc)
+		if rendered.is_empty():
+			continue
+		for r in rendered:
+			lines.append("\t" + r)
+		emitted_anything = true
+	if not emitted_anything:
+		lines.append("\tpass")
+	lines.append("\treturn")
+	return lines
+
+func _emit_opcode(opc : Dictionary) -> Array:
+	var name : String = opc["name"]
+	var args : String = opc["args"]
+	match name:
+		"exit_ap":
+			# `return` is appended unconditionally at the end of every AP, so
+			# emitting nothing for an explicit exit_ap is fine.
+			return []
+		"string":
+			return [_emit_string(args)]
+		"sound":
+			return [_emit_sound(args)]
+		"set_dungeon":
+			return _emit_set_dungeon(args)
+		"simple_enc":
+			return ["await ScriptHelperFuncsClass.display_simple_encounter_Divinity(%s)" % _strip_prefix_int(args, "SEC")]
+		"complex_enc":
+			return ["await ScriptHelperFuncsClass.start_complex_encounter_Divinity(%s)" % _strip_prefix_int(args, "CEC")]
+		"treasure":
+			return ["await ScriptHelperFuncsClass.give_treasure_with_id(%s)" % _strip_prefix_int(args, "TSR")]
+		"give_map":
+			return ["ScriptHelperFuncsClass.give_minimap(%s)" % args.strip_edges()]
+		"enable_dungeon_map", "disable_dungeon_map":
+			return ["# TODO[%s]: %s" % [name, args]]
+		_:
+			unhandled_opcodes[name] = int(unhandled_opcodes.get(name, 0)) + 1
+			return ["# TODO[%s]: %s" % [name, args]]
+
+func _emit_string(args : String) -> String:
+	# args looks like:  "...text..."#200, no_wait
+	# or                "...text..."
+	# or                0   (meaning "no string" — original game uses sentinel)
+	var s := args.strip_edges()
+	if s == "0":
+		return "# TODO[string]: sentinel-zero (no text)"
+	# Pull out the quoted body.
+	var first_q := s.find('"')
+	if first_q == -1:
+		return "# TODO[string]: %s" % s
+	# Find matching unescaped close quote.
+	var i := first_q + 1
+	while i < s.length():
+		var c := s[i]
+		if c == "\\":
+			i += 2
+			continue
+		if c == '"':
+			break
+		i += 1
+	if i >= s.length():
+		return "# TODO[string]: %s" % s
+	var body := s.substr(first_q + 1, i - first_q - 1)
+	# Convert to a single-quoted GDScript literal, escaping single quotes and
+	# leaving existing escape sequences alone.
+	var literal := _to_gd_single_quoted(body)
+	return "await ScriptHelperFuncsClass.display_text_wait_noise(%s, %s)" % [literal, SFX_DEFAULT]
+
+func _to_gd_single_quoted(body : String) -> String:
+	# Existing files emit single-quoted strings with embedded \" escapes intact.
+	# We don't need to re-escape inner double-quotes (since we wrap in single
+	# quotes), but we must escape literal single quotes and backslashes.
+	var out := ""
+	var i := 0
+	while i < body.length():
+		var c := body[i]
+		if c == "\\" and i + 1 < body.length():
+			# Pass through original escape (e.g. \" or \\) unchanged.
+			out += body.substr(i, 2)
+			i += 2
+			continue
+		if c == "'":
+			out += "\\'"
+		else:
+			out += c
+		i += 1
+	return "'" + out + "'"
+
+func _emit_sound(args : String) -> String:
+	# args looks like:  30000           or  30000, pause
+	var first := args.split(",")[0].strip_edges()
+	if first.is_valid_int():
+		return "ScriptHelperFuncsClass.play_sound_divinity(%s)" % first
+	return "# TODO[sound]: %s" % args
+
+func _emit_set_dungeon(args : String) -> Array:
+	# args:  1(land), level=5, x=21, y=5, dir=0
+	# or     0(dungeon), level=N, x=X, y=Y, dir=D    (we don't have a divinity
+	# helper for dungeon-target teleports yet — emit TODO for those)
+	var mode_re := RegEx.new()
+	mode_re.compile("^(\\d+)\\(([a-zA-Z]+)\\)")
+	var m := mode_re.search(args)
+	if m == null:
+		return ["# TODO[set_dungeon]: %s" % args]
+	var dest_kind : String = m.get_string(2)
+	if dest_kind != "land":
+		return ["# TODO[set_dungeon to %s]: %s" % [dest_kind, args]]
+	var lvl : int = _kv_int(args, "level")
+	var tx : int = _kv_int(args, "x")
+	var ty : int = _kv_int(args, "y")
+	if lvl < 0 or tx < 0 or ty < 0:
+		return ["# TODO[set_dungeon]: %s" % args]
+	return ["ScriptHelperFuncsClass.teleport_to_map_and_pos_divinity(%d, %d, %d, 0)" % [lvl, tx, ty]]
+
+# ------------------------------------------------------------------
+# helpers
+# ------------------------------------------------------------------
+
+func _strip_prefix_int(s : String, prefix : String) -> String:
+	var t := s.strip_edges()
+	if t.begins_with(prefix):
+		return t.substr(prefix.length())
+	return t  # leave as-is; review will catch it
+
+func _kv_int(args : String, key : String) -> int:
+	# Returns the int value of `key=N` in `args`, or -1 if missing/unparseable.
+	var re := RegEx.new()
+	re.compile("\\b%s=(-?\\d+)" % key)
+	var m := re.search(args)
+	if m == null:
+		return -1
+	return m.get_string(1).to_int()

--- a/src/addons/realmz_dump_importer/script_emitter.gd.uid
+++ b/src/addons/realmz_dump_importer/script_emitter.gd.uid
@@ -1,0 +1,1 @@
+uid://ctjyfhjc70uft

--- a/src/project.godot
+++ b/src/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Realmz"
-config/version="0.1.105"
+config/version="0.1.106"
 run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.6")
 boot_splash/bg_color=Color(0, 0, 0, 1)

--- a/src/project.godot
+++ b/src/project.godot
@@ -45,7 +45,7 @@ export/convert_text_resources_to_binary=false
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/godot-openmpt/plugin.cfg", "res://addons/realmz_export_plugin/plugin.cfg")
+enabled=PackedStringArray("res://addons/godot-openmpt/plugin.cfg", "res://addons/realmz_dump_importer/plugin.cfg", "res://addons/realmz_export_plugin/plugin.cfg")
 
 [filesystem]
 


### PR DESCRIPTION
## Summary

Adds an EditorPlugin (`addons/realmz_dump_importer/`) that converts Realmz scenario text dumps (the *City of Bywater full script* dump and friends) into the project's `map_scriptareas.json` + `map_scripts.gd` file pair, **for every map in the dump in one click**. Wired into `project.godot`'s `[editor_plugins]` list so no per-clone setup is needed.

**Motivation:** `map_0` is fully hand-ported (95 LAP funcs + 168 XAP funcs in `map_scripts.gd`, matching the dump's 95 `LAP0/*` entries) but `map_1`..`map_8` and the dungeon levels are mostly empty stubs. The dump format is structured opcode-per-line, so the conversion is mechanical work that the tool runs in seconds.

## What's in this PR

| File | Purpose |
|---|---|
| `plugin.cfg` / `plugin.gd` | Registers a **Project → Tools → Realmz: Import Scenario Dump...** entry. |
| `dump_parser.gd` | Reads the dump, strips stray null bytes the export tool leaves in string payloads, emits section records (`LAND_AP`, `DUNGEON_AP`, RRs, XAPs, …). Includes `discover_ap_levels()` so the bulk import can auto-enumerate every map. |
| `script_emitter.gd` | Emits one `map_scriptareas.json` + `map_scripts.gd` pair for a `(kind, level)` pair, using the existing `map_0` patterns. Translates the common opcodes 1:1 to `ScriptHelperFuncsClass` helpers; anything else becomes `# TODO[<opcode>]: <args>`. |
| `import_dialog.gd` | Modal dialog. Default flow: pick dump → pick Maps dir → click Import All → result table for every map. Single-map mode hidden behind an Advanced toggle. |
| `README.md` | Usage + opcode coverage table + design notes. |

## UX

```
Dump file:        [path]                              [Pick Dump File...]
Campaign Maps:    [res://Campaigns/City of Bywater/Maps/]
[ ] Force overwrite (bypass already-ported skip — DANGEROUS for map_0)
[X] Dry-run (preview only — print to log, don't write files)
[ ] Show advanced options (single-map mode)

(log textarea — result table per map)
                                              [Import All] [Pick...] [Close]
```

Three safety mechanisms:

- **Skip-if-already-ported (default ON):** before writing a map's `map_scripts.gd`, count `static func` defs in the existing file. ≥ 20 → assume hand-ported and skip with reason. `map_0`'s 263 funcs are well above the threshold; the importer never touches it without **Force overwrite**.
- **Force overwrite (default OFF):** bypasses the skip when you actually do want to regenerate.
- **Dry-run (default ON):** writes nothing; reports per-map sizes, unhandled-opcode counts, and `WOULD-SKIP` for already-ported maps so the preview predicts the real run.

## Evidence the importer produces faithful CoB output

### A. Bulk-import dry-run (one click against the CoB dump)

```
=== Run #2 @ 00:12:40 ===
Parsing C:/Users/jsnor/Downloads/CoB full script w all random strings.txt ...
  -> 1914 sections parsed
Mode: DRY-RUN (skip already-ported)

MAP      KIND     APs      RESULT
map_0    LAND     95       DRY-RUN (json 12608 B, gd 43639 B; 23 unhandled opcodes)
map_1    LAND     37       DRY-RUN (json 6309 B, gd 14587 B; 8 unhandled opcodes)
map_2    LAND     12       DRY-RUN (json 3620 B, gd 4571 B; 6 unhandled opcodes)
map_3    LAND     23       DRY-RUN (json 4801 B, gd 9988 B; 7 unhandled opcodes)
map_4    LAND     47       DRY-RUN (json 7333 B, gd 19914 B; 11 unhandled opcodes)
map_5    LAND     97       DRY-RUN (json 12917 B, gd 33904 B; 14 unhandled opcodes)
map_6    LAND     56       DRY-RUN (json 8372 B, gd 18400 B; 10 unhandled opcodes)
map_7    LAND     98       DRY-RUN (json 13000 B, gd 33431 B; 15 unhandled opcodes)
map_8    LAND     97       DRY-RUN (json 12855 B, gd 33694 B; 15 unhandled opcodes)
mapd_0   DUNGEON  23       DRY-RUN (json 4819 B, gd 8260 B; 5 unhandled opcodes)
mapd_1   DUNGEON  91       DRY-RUN (json 12249 B, gd 32463 B; 16 unhandled opcodes)

Done.
```

11 maps, 676 APs total, processed in one click. (The latest commit `4704146` makes the `map_0` row read `WOULD-SKIP (already ported: 263 funcs)` instead of `DRY-RUN`, so the dry-run table now predicts which maps the real run would touch.)

### B. Faithfulness exhibit — the trap-door round trip from #83

This is the exact scenario PR #83 (closed) got wrong. Both APs are reproduced from the dump verbatim:

**Dump record (line 34160 of the CoB dump):**
```
===== LAND AP level=0 id=25 x=16 y=17 to_level=5 to_x=21 to_y=5 [LAP0/25]
  string                   "The doors on this crypt are broken as are most in the graveyard.  As you peer in, you happen to see a small crack in the floor.  Your investigation reveals that it is a trap door that leads to a subterranean crypt."#200, no_wait
  exit_ap
```

**What the importer emits for `map_0/map_scripts.gd`:**
```gdscript
static func AP25x16y17() : #25 at 16,17
	# Header teleport: to_level=5 to_x=21 to_y=5
	ScriptHelperFuncsClass.teleport_to_map_and_pos_divinity(5, 21, 5, 0)
	await ScriptHelperFuncsClass.display_text_wait_noise('The doors on this crypt are broken as are most in the graveyard.  As you peer in, you happen to see a small crack in the floor.  Your investigation reveals that it is a trap door that leads to a subterranean crypt.', 'message nod.wav')
	return
```

Teleport target is **(21, 5)** — matches the dump's `to_x=21 to_y=5` — *not* the (21, 4) my hand-edit in #83 incorrectly used. Faithful by construction.

---

**Dump record (line 35371 of the CoB dump):**
```
===== LAND AP level=5 id=1 x=21 y=4 to_level=0 to_x=16 to_y=16 [LAP5/1]
  exit_ap
```

**What the importer emits for `map_5/map_scripts.gd`:**
```gdscript
static func AP1x21y4() : #1 at 21,4
	# Header teleport: to_level=0 to_x=16 to_y=16
	ScriptHelperFuncsClass.teleport_to_map_and_pos_divinity(0, 16, 16, 0)
	return
```

This is the canonical "Stairs Up" tile from the original game: at `map_5 (21, 4)`, returning the party to `map_0 (16, 16)`. Both endpoint coordinates match the dump exactly.

### C. Opcode coverage analysis

Tallied opcode frequency across every LAND/DUNGEON AP body in the CoB dump:

| Rank | Opcode | Occurrences | Status |
|---|---|---|---|
| 1 | `string` | 658 | ✅ handled |
| 2 | `exit_ap` | 263 | ✅ handled |
| 3 | `sound` | 148 | ✅ handled |
| 4 | `battle` | 101 | ❌ TODO (planned next PR) |
| 5 | `option` | 77 | ❌ TODO (planned next PR) |
| 6 | `treasure` | 71 | ✅ handled |
| 7 | `change_tile` | 71 | ❌ TODO (planned next PR) |
| 8 | `tele` | 53 | ❌ TODO (planned next PR) |
| 9 | `jmp_battle` | 44 | ❌ TODO (planned next PR) |
| 10 | `jmp_xap` | 29 | ❌ TODO (planned next PR) |
| 11 | `enable_ap` | 22 | ❌ TODO (planned next PR) |
| 12 | `simple_enc` | 18 | ✅ handled |
| 13–25 | (long tail) | <17 each | mixed |

**This PR covers ~72% of all opcode occurrences.** Adding the seven highlighted opcodes in a follow-up PR brings it to ~97%. The rest is a long tail that will be addressed opcode-by-opcode as their helper-call conventions get verified against the `map_0` hand-port.

## Test plan

- [ ] Pull the branch, open the project in Godot. Confirm **Project → Tools → Realmz: Import Scenario Dump...** appears in the menu.
- [ ] Open the dialog, pick the CoB dump `.txt`, leave **Dry-run** on, click **Import All**. Result table should match section A above (modulo `map_0` showing `WOULD-SKIP` after the latest commit).
- [ ] Tick **Show advanced options → Single-map mode**, set Level=0 + LAND, click **Import All**. Confirm only `map_0` is processed and it still reports `WOULD-SKIP`.
- [ ] Tick **Force overwrite**, leave Dry-run on, click **Import All**. Now every map should report `DRY-RUN` (skip is bypassed). No files written either way.
- [ ] Confirm the existing `realmz_export_plugin` and `godot-openmpt` are still listed/enabled (the change to `project.godot` only appends to the array).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
